### PR TITLE
Add quest management CLI and convert Tan Thu quest data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,83 +1,101 @@
 # QuestTools
 
-QuestTools cung cấp bộ công cụ dòng lệnh để quản trị và trích xuất dữ liệu nhiệm vụ (quest) từ các tài liệu dạng văn bản thô.
-Bộ công cụ đã được sử dụng để chuyển đổi tài liệu **“Cốt truyện và Nhiệm vụ Tân thủ”** thành dữ liệu JSON có cấu trúc và đi kèm
-các lệnh hỗ trợ quản lý, cập nhật dữ liệu.
+QuestTools cung cấp cả giao diện web hiện đại lẫn bộ công cụ dòng lệnh để quản trị và trích xuất dữ liệu nhiệm vụ (quest)
+cho các trò chơi nhập vai. Bộ công cụ đã được áp dụng cho tài liệu **“Cốt truyện và Nhiệm vụ Tân thủ”** và lưu trữ
+thành cấu trúc JSON sẵn sàng sử dụng.
 
-## Các tính năng chính
+## Tính năng chính
 
-* Chuyển đổi tài liệu văn bản định dạng danh sách nhiệm vụ sang JSON.
-* Liệt kê, hiển thị chi tiết từng nhiệm vụ từ tập tin JSON.
-* Thêm, cập nhật, xóa nhiệm vụ trực tiếp thông qua dòng lệnh.
-* Mẫu dữ liệu thực tế của bộ nhiệm vụ Tân thủ (`data/quests/tan_thu.json`).
+- **Giao diện web chuyên nghiệp**: trình quản trị trực quan cho phép tìm kiếm, thêm, sửa, xoá nhiệm vụ, chỉnh sửa tổng quan
+  tài liệu và xem ngay các đoạn hội thoại/ghi chú. Giao diện được xây dựng với Bootstrap 5, hỗ trợ bàn phím và cả thiết bị di động.
+- **Đồng bộ trực tiếp với tập tin JSON**: mọi thao tác trong UI ghi nhận ngay vào tập tin dữ liệu, đảm bảo dữ liệu luôn nhất quán
+  với các công cụ khác.
+- **Bộ công cụ CLI đầy đủ**: tiếp tục hỗ trợ các lệnh `convert`, `list`, `show`, `add`, `update`, `remove` cho các quy trình tự động.
+- **Bộ dữ liệu mẫu**: file `data/quests/tan_thu.json` đã được chuẩn hoá từ tài liệu gốc `data/raw/tan_thu.txt`.
 
-## Sử dụng nhanh
+## Cài đặt
 
-Các ví dụ dưới đây giả định bạn đang đứng tại thư mục gốc của dự án.
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements.txt
+```
+
+## Giao diện quản trị web
+
+Chạy máy chủ quản trị bằng lệnh:
+
+```bash
+python -m questtools serve data/quests/tan_thu.json --open
+```
+
+Trình duyệt sẽ mở đến `http://127.0.0.1:8000/` với các chức năng:
+
+- Bảng điều hướng nhiệm vụ có tìm kiếm theo tiêu đề hoặc NPC.
+- Biểu mẫu chỉnh sửa tổng quan tài liệu (tiêu đề, phần mô tả).
+- Biểu mẫu chi tiết nhiệm vụ hỗ trợ các trường danh sách (mục tiêu, hội thoại, ghi chú) và trường mở rộng dạng JSON.
+- Tạo nhiệm vụ mới, lưu thay đổi hoặc xoá ngay trên giao diện.
+
+> Nếu muốn khởi động mà không tự mở trình duyệt, bỏ tuỳ chọn `--open`.
+
+Bạn cũng có thể chạy launcher độc lập:
+
+```bash
+python -m questtools.ui_launcher --data data/quests/tan_thu.json --open
+```
+
+Launcher này là điểm vào được dùng cho bản đóng gói (PyInstaller).
+
+## Bộ công cụ CLI truyền thống
+
+Các lệnh CLI vẫn giữ nguyên. Ví dụ:
 
 ```bash
 # Chuyển đổi tài liệu văn bản sang JSON
 python -m questtools convert data/raw/tan_thu.txt data/quests/tan_thu.json --title "Cốt truyện và Nhiệm vụ Tân thủ"
 
-# Liệt kê các nhiệm vụ
+# Liệt kê nhiệm vụ
 python -m questtools list data/quests/tan_thu.json
 
-# Xem chi tiết nhiệm vụ có id = 3
+# Xem chi tiết nhiệm vụ
 python -m questtools show data/quests/tan_thu.json 3
 
 # Thêm nhiệm vụ mới
-python -m questtools add data/quests/tan_thu.json "Tên nhiệm vụ" \
-    --description "Mô tả nhiệm vụ" \
-    --accept-npc "NPC nhận" \
-    --targets "Hoàn thành điều kiện 1" --targets "Hoàn thành điều kiện 2"
+python -m questtools add data/quests/tan_thu.json "Tên nhiệm vụ" --description "Mô tả" --targets "Điều kiện 1"
 
-# Cập nhật nhiệm vụ hiện có
+# Cập nhật hoặc xoá nhiệm vụ
 python -m questtools update data/quests/tan_thu.json 3 --description "Mô tả mới"
-
-# Xóa nhiệm vụ khỏi danh sách
 python -m questtools remove data/quests/tan_thu.json 10
 ```
 
-Các lệnh `add` và `update` hỗ trợ các tham số lặp (`--dialog-accept`, `--dialog-complete`, `--targets`, `--notes`) để khai báo
-nhiều dòng hội thoại hoặc mục tiêu.
+## Kiểm thử
 
-## Cấu trúc dữ liệu
-
-Tập tin JSON được tạo ra có dạng:
-
-```json
-{
-  "title": "Cốt truyện và Nhiệm vụ Tân thủ",
-  "overview": "...",
-  "quests": [
-    {
-      "id": 1,
-      "title": "Rừng tre ban sớm",
-      "description": "...",
-      "accept_npc": "...",
-      "dialog_accept": ["..."],
-      "targets": ["..."],
-      "notes": ["..."],
-      "extra_fields": {}
-    }
-  ]
-}
-```
-
-## Chạy kiểm thử
-
-Dự án sử dụng `unittest` cho bộ kiểm thử đơn giản:
+Dự án sử dụng `unittest`:
 
 ```bash
-python -m unittest
+python -m unittest discover
 ```
+
+Các bài kiểm thử bao gồm cả lớp repository và API FastAPI.
+
+## Đóng gói bản chạy độc lập
+
+Bạn có thể dùng PyInstaller để tạo bản build chỉ cần tải về và chạy:
+
+```bash
+pip install pyinstaller
+pyinstaller packaging/questtools_ui.spec
+```
+
+Sau khi hoàn tất, thư mục `dist/QuestToolsUI/` chứa file thực thi:
+
+```bash
+./dist/QuestToolsUI/QuestToolsUI --open
+```
+
+Tập tin JSON mẫu và các tài nguyên giao diện đã được gom sẵn trong bản build thông qua file spec.
 
 ## Thư mục dữ liệu
 
-* `data/raw/tan_thu.txt` – tài liệu văn bản gốc.
-* `data/quests/tan_thu.json` – kết quả chuyển đổi sang JSON.
-
-## Phát triển thêm
-
-Bộ công cụ được xây dựng bằng Python thuần, không phụ thuộc vào thư viện ngoài. Bạn có thể mở rộng bằng cách bổ sung các lệnh mới
-hoặc tinh chỉnh bộ phân tích trong `questtools/parser.py` để phù hợp với định dạng tài liệu của riêng mình.
+- `data/raw/tan_thu.txt` – tài liệu văn bản gốc.
+- `data/quests/tan_thu.json` – kết quả chuyển đổi sang JSON.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
 # QuestTools
+
+QuestTools cung cấp bộ công cụ dòng lệnh để quản trị và trích xuất dữ liệu nhiệm vụ (quest) từ các tài liệu dạng văn bản thô.
+Bộ công cụ đã được sử dụng để chuyển đổi tài liệu **“Cốt truyện và Nhiệm vụ Tân thủ”** thành dữ liệu JSON có cấu trúc và đi kèm
+các lệnh hỗ trợ quản lý, cập nhật dữ liệu.
+
+## Các tính năng chính
+
+* Chuyển đổi tài liệu văn bản định dạng danh sách nhiệm vụ sang JSON.
+* Liệt kê, hiển thị chi tiết từng nhiệm vụ từ tập tin JSON.
+* Thêm, cập nhật, xóa nhiệm vụ trực tiếp thông qua dòng lệnh.
+* Mẫu dữ liệu thực tế của bộ nhiệm vụ Tân thủ (`data/quests/tan_thu.json`).
+
+## Sử dụng nhanh
+
+Các ví dụ dưới đây giả định bạn đang đứng tại thư mục gốc của dự án.
+
+```bash
+# Chuyển đổi tài liệu văn bản sang JSON
+python -m questtools convert data/raw/tan_thu.txt data/quests/tan_thu.json --title "Cốt truyện và Nhiệm vụ Tân thủ"
+
+# Liệt kê các nhiệm vụ
+python -m questtools list data/quests/tan_thu.json
+
+# Xem chi tiết nhiệm vụ có id = 3
+python -m questtools show data/quests/tan_thu.json 3
+
+# Thêm nhiệm vụ mới
+python -m questtools add data/quests/tan_thu.json "Tên nhiệm vụ" \
+    --description "Mô tả nhiệm vụ" \
+    --accept-npc "NPC nhận" \
+    --targets "Hoàn thành điều kiện 1" --targets "Hoàn thành điều kiện 2"
+
+# Cập nhật nhiệm vụ hiện có
+python -m questtools update data/quests/tan_thu.json 3 --description "Mô tả mới"
+
+# Xóa nhiệm vụ khỏi danh sách
+python -m questtools remove data/quests/tan_thu.json 10
+```
+
+Các lệnh `add` và `update` hỗ trợ các tham số lặp (`--dialog-accept`, `--dialog-complete`, `--targets`, `--notes`) để khai báo
+nhiều dòng hội thoại hoặc mục tiêu.
+
+## Cấu trúc dữ liệu
+
+Tập tin JSON được tạo ra có dạng:
+
+```json
+{
+  "title": "Cốt truyện và Nhiệm vụ Tân thủ",
+  "overview": "...",
+  "quests": [
+    {
+      "id": 1,
+      "title": "Rừng tre ban sớm",
+      "description": "...",
+      "accept_npc": "...",
+      "dialog_accept": ["..."],
+      "targets": ["..."],
+      "notes": ["..."],
+      "extra_fields": {}
+    }
+  ]
+}
+```
+
+## Chạy kiểm thử
+
+Dự án sử dụng `unittest` cho bộ kiểm thử đơn giản:
+
+```bash
+python -m unittest
+```
+
+## Thư mục dữ liệu
+
+* `data/raw/tan_thu.txt` – tài liệu văn bản gốc.
+* `data/quests/tan_thu.json` – kết quả chuyển đổi sang JSON.
+
+## Phát triển thêm
+
+Bộ công cụ được xây dựng bằng Python thuần, không phụ thuộc vào thư viện ngoài. Bạn có thể mở rộng bằng cách bổ sung các lệnh mới
+hoặc tinh chỉnh bộ phân tích trong `questtools/parser.py` để phù hợp với định dạng tài liệu của riêng mình.

--- a/data/quests/tan_thu.json
+++ b/data/quests/tan_thu.json
@@ -1,0 +1,779 @@
+{
+  "title": "Cốt truyện và Nhiệm vụ Tân thủ",
+  "overview": "Cốt truyện và Nhiệm vụ Tân thủ\nContents\nCốt truyện và Nhiệm vụ Tân thủ1\nSơ lược nội dung3\nChi tiết5\n1.Rừng tre ban sớm5\n2.Bóng đen trong rừng6\n3.Một sáng Tức Mặc7\n4.Lời thưa nơi đình Tức Mặc8\n5.Võ học làng Tức Mặc9\n6.Bát chè xanh đầu ngõ10\n7.Gáo nước giếng làng11\n8.Búa lửa trong lò12\n9.Lời đồn chợ quê13\n10.Dò chuyện ở chợ 1 – Lời thuế nặng trĩu14\n11.Dò chuyện ở chợ 2 – Tiếng đồn tiếng chợ15\n12.Dò chuyện ở chợ 3 – Mùi mắm mùi đời16\n13.Dò chuyện ở chợ 4 – Mảnh giấy miếng trầu17\n14.Thương nhân mấu chốt19\n15.Ba chiếc phong thư21\n16.Giao thư 1 - Hơi thở an tĩnh22\n17.Giao thư 2 – Thỏ xào và lá thuốc23\n18.Giao thư 3 – Gậy già chờ tay24\n19.Lời đồn rừng tây25\n20.Tìm mẹo trấn âm26\n21.Mồi cá bên sông28\n22.Cựa gà trên sân29\n23.Cực dương30\n24.Một cái đầu lơ lửng31\n25.Khúc gỗ lim giữa rừng31\n26.Căn lều trong rừng sâu31\n27.Cây gỗ tốt32\n28.Gậy chống làng33\n29.Đêm họp dưới đèn33\n30.Những ngày chuẩn bị34\n\n\nSơ lược nội dung\nNăm 1283, tại làng Tức Mặc. Nhân vật chính (NVC) là một dân làng bình thường, cha là dân binh hy sinh trong trận chiến chống quân Mông - Nguyên lần thứ nhất, mẹ vì đau buồn mà sinh bệnh rồi cũng qua đời, NVC sống lặng lẽ nhờ rừng tre và chiếc rìu cũ. Một buổi tờ mờ sáng cũng như bao ngày, NVC vào rừng tre thì phát hiện có tiếng tranh cãi, NVC nghe lén ba kẻ áo đen tính mưu phá hoại: trách nhau rằng bạc vàng của Đại Hãn bao lâu qua đã hao phí, rồi bàn nhau chỉ cần gây loạn ở Tức Mặc, đó sẽ là mồi lửa đầu tiên để lòng dân lung lay. Bị phát hiện và giao chiến, sức yếu nên NVC ngất đi, may được lính gác đưa về nhà thầy thuốc Trần Xuân Lang.\nTỉnh lại, NVC đến đình trình báo. Lý trưởng Trần Thế Lục dặn phải giữ kín, đồng thời gửi NVC sang tập võ với Trần Thế Sương. Ở sân tập, cùng sự thử sức của chàng trai Huy Phong, anh lần đầu cầm vũ khí chiến đấu → unlock: chọn vũ khí đầu tiên.\nTrong khi đó, làng bắt đầu xôn xao với tin đồn “triều đình vét thuế”. Sau khi giúp ông rèn Trần Thế Kim → unlock: Rèn. Ông mới nói cho NVC nghe về mấy lời đồn gần đây, NVC quay về báo tin lý trưởng và NVC được giao xuống chợ dò hỏi. Có người tin, có người phủ nhận, và cuối cùng Trần Thị Quýt trao cho NVC một tờ yết thị làm giả con dấu triều đình. Thương nhân Trần Đăng Kiến sau khi xem đã nhận ra đây là giấy lạ, chắc chắn có bàn tay ngoài làng. Tin được báo lại cho Lý trưởng, và ông quyết định họp kín các bô lão.\nTrước buổi họp, NVC được giao mang thư mời đến ba người trụ cột.\n•Trần Thế Sương dạy NVC ngồi thiền, giữ tâm vững trước sóng gió → unlock: Ngồi thiền.\n•Thầy thuốc Xuân Lang hướng dẫn hái thuốc, bẫy thỏ, chế thuốc và nấu ăn; Quỳnh còn nấu cho NVC thịt thỏ xào thảo dược → unlock: Chế thuốc + Nấu ăn.\n•Lão Trần Tri - cựu binh già mất cả ba con trai trong kháng chiến - nhờ anh đi tìm cây gậy lim mới để chống cho thời gian tới vì có thể cơ sự nhiều, cần phải đi lại.\nNVC đến xưởng gỗ Trần Đăng Mục, biết rằng gỗ lim tốt chỉ có trong rừng tây, nơi bị đồn có ma lai. Theo lời bà Mắm, để trấn áp tà khí cần “trứng gà + nước tiểu đồng tử”.\n•Anh gặp cu Lỳ bên sông, câu cá cùng một lúc rồi lấy được nước tiểu → unlock: Câu cá.\n•Sau đó gặp Trần Kê ở sân đá gà, cá cược chọn gà thắng và được thưởng trứng → unlock: Đá gà.\nPha chế theo lời bà Mắm, anh vào rừng, đối mặt và đánh bại ma lai. Trong lúc tìm cây gỗ tốt, NVC tình cờ phát hiện một ngôi lều lạ. Bên trong có hai kẻ khả nghi, miệng nhắc đến “Đại Hãn”. Trong lúc NVC nghi vấn Ma lai là trò che mắt của chúng để người ta không bén mảng để chỗ cắm trại. Chúng phát hiện ra NVC, một trận chiến kịch liệt nổ ra. Lần này, nhờ võ nghệ đã luyện, anh không còn yếu thế. Chúng rõ ràng cùng hội với ba kẻ áo đen trước đó nhưng lực yếu hơn. Cuối cùng, khi NVC vừa lùi ra, chúng dùng thủ thuật che mắt để tẩu thoát, để lại lều và một mớ những giấy “Yết thị” giả kia. Không kịp truy đuổi, NVC đành mang gỗ lim về.\nTrần Đăng Mục sau đó gia công thành cây gậy chắc chắn cho lão Trần Tri. → unlock: Nghề mộc (chế gỗ)\nCuộc họp kín diễn ra tại nhà thuốc Xuân Lang. NVC báo cáo lại toàn bộ: từ tờ yết thị giả, đến chuyện gặp hai kẻ nhắc “Đại Hãn”. Các bô lão tin chắc rằng đây là âm mưu từ bên ngoài. Kế hoạch được định: Trần Thế Sương lo huấn luyện trai tráng, Xuân Lang chuẩn bị thuốc men và lương thảo, Trần Tri trấn an bô lão, còn nhân vật chính - ít bị chú ý - sẽ thay mặt làng mang thư mật lên Thăng Long → unlock: Nhiệm vụ chính - Hành trình Thăng Long.\nSau nhiều ngày rèn luyện và chuẩn bị (level cap để yêu cầu làm thêm nhiệm vụ phụ), sáng hôm khởi hành, Lý trưởng trao cho NVC ba phong thư niêm kín, dặn dò phải giữ vững chí khí. Từ một tiều phu vô danh, NVC nay mang trọng trách lớn lao: lên đường rời Tức Mặc, đem theo gánh nặng yên bình của ngôi làng, và rộng hơn là cả Đại Việt.\n\nChi tiết",
+  "quests": [
+    {
+      "id": 1,
+      "title": "Rừng tre ban sớm",
+      "description": "Vác rìu đi vào rừng tre lúc rạng sáng. Vô tình nghe ba kẻ lạ bàn mưu.",
+      "accept_npc": "(Auto - mở màn)",
+      "complete_npc": "(Auto - khi bị phát hiện)",
+      "dialog_accept": [
+        "οGiọng khàn: “Bao nhiêu năm rồi mà cái xứ Đại Việt này vẫn yên bình thế kia… chẳng lẽ bạc vàng của Đại Hãn lại đổ sông đổ biển hết sao?”",
+        "οGiọng trầm: “Ngươi nóng nảy quá. Bề ngoài yên ổn thôi, chỉ cần một vết rạn nhỏ thì cả triều đình sẽ lung lay. Việc của chúng ta là châm cái vết rạn đó.”",
+        "οGiọng thứ ba, dứt khoát: “Ngay tại chốn làng quê này cũng đủ. Nếu Tức Mặc loạn, lòng người khắp nơi sẽ bất an. Chúng sẽ thấy triều Trần không còn bất khả xâm phạm nữa.”",
+        "οNhân vật chính: “Quái lạ… rạng sáng nay sao lại có người trong rừng? Lời lẽ nghe toàn chuyện phản nghịch… Ta… ta phải nhìn cho rõ.”"
+      ],
+      "dialog_complete": [
+        "οÁo đen A: “Ai!? Ai đang nấp trong bụi kia? Mau ra!”",
+        "οÁo đen B: “Có kẻ nghe lén! Bắt nó!”"
+      ],
+      "targets": [
+        "οĐi theo đường mòn vào rừng."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 2,
+      "title": "Bóng đen trong rừng",
+      "description": "Bị phát hiện, chống trả đám áo đen giữa rừng tre. Rồi lúc lính canh đến thì ngất vì kiệt sức.",
+      "accept_npc": "(Auto - tiếp nối Quest 1)",
+      "complete_npc": "(Auto - khi địch rút chạy)",
+      "dialog_accept": [
+        "οÁo đen C: “Một thằng tiều phu nhãi ranh mà cũng dám mở miệng hỏi tội? Ngươi đã nghe hết rồi thì sống làm gì nữa.”",
+        "οÁo đen A: “Nhanh! Giết nó, chặt đầu vứt xuống suối, đừng để lại dấu vết.”"
+      ],
+      "dialog_complete": [
+        "οLính gác: “Ai đó trong rừng? Đứng lại! Lính tuần đây! Mau ra!”",
+        "οÁo đen A: “Khốn kiếp, lính đến rồi!”",
+        "οÁo đen B: “Không kịp giết nó nữa, rút mau!”",
+        "οÁo đen C: “Nhưng nếu nó sống...”",
+        "οÁo đen A: “Im! Giữ mạng đã, đi!”"
+      ],
+      "targets": [
+        "οGiao đấu với nhóm áo đen."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 3,
+      "title": "Một sáng Tức Mặc",
+      "description": "Tỉnh lại tại nhà thầy thuốc Trần Xuân Lang.",
+      "accept_npc": "(Auto)",
+      "complete_npc": "Trần Xuân Lang",
+      "dialog_accept": [
+        "οTrần Xuân Quỳnh: “Huynh tỉnh rồi! Trời ơi, ta cứ tưởng… đêm qua ta run hết cả người, ngỡ rằng huynh không qua nổi. May mà mấy chú lính gác tuần tra nghe thấy tiếng ẩu đả, họ chạy đến, thấy huynh nằm lăn ngay dưới chân đám áo đen. Họ vừa kịp cõng huynh về đây thôi.”",
+        "οNhân vật chính: “Thật may quá, cứ ngỡ phải toi rồi”",
+        "οTrần Xuân Quỳnh: “Huynh liều quá. Đêm hôm, rạng sáng một mình vác rìu vào rừng… Lần này còn có người đưa về, chứ nếu trễ thêm một khắc thì…”",
+        "οTrần Xuân Lang: “Được rồi, Quỳnh, để ta xem cho rõ.”",
+        "οTrần Xuân Lang: “Ừm… chỉ là kiệt sức, mạch cũng tốt hơn rồi. Đánh đến thế này. bọn kia không phải cướp vặt đâu.”",
+        "οNhân vật chính: “Tôi nghe chúng nói… muốn gieo loạn ngay tại Tức Mặc… Nếu là thật thì- ”",
+        "οTrần Xuân Lang: “Không. Lời ấy chưa được thốt ra ngoài. Ngươi nhớ kỹ: dân làng mà nghe loáng thoáng, lo sợ nổi lên thì bọn kia sẽ đạt mưu. Ngươi còn yếu, lo dưỡng sức. Khi nào gượng dậy được, hãy tự đến đình mà trình bày với Lý trưởng. Đó mới là lẽ phải.”",
+        "οNhân vật chính: “Tôi… tôi hiểu. Nhưng hình ảnh chúng nói cứ vang trong đầu, chẳng xua đi nổi…”",
+        "οTrần Xuân Quỳnh: “Uống chút nước đi. Huynh nằm yên, đừng nghĩ ngợi. Để chuyện lớn cho cha và các bô lão lo. Huynh chỉ cần giữ mạng cho chắc.”",
+        "οNhân vật chính: “Cảm ơn… Quỳnh… Cảm ơn thầy Lang… Lần này, nếu không có mọi người… tôi đã nằm lại trong rừng tre rồi.”",
+        "οTrần Xuân Lang: “Thân còn thì việc còn. Hãy nhớ: giữ kín miệng, giữ vững thân. Chuyện ở rừng, rồi sẽ có ngày đưa ra ánh sáng, nhưng không phải bằng miệng dân đồn đãi. Nghỉ đi.”"
+      ],
+      "dialog_complete": [],
+      "targets": [
+        "οNói chuyện với Trần Xuân Quỳnh và Trần Xuân Lang"
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 4,
+      "title": "Lời thưa nơi đình Tức Mặc",
+      "description": "Tới đình, yết kiến Lý trưởng Trần Thế Lục. Thuật lại chuyện rừng tre.",
+      "accept_npc": "Trần Thế Lục",
+      "complete_npc": "Trần Thế Lục",
+      "dialog_accept": [
+        "οTrần Thế Lục: “Ngươi đó à? Ta nghe lính gác báo lại có kẻ lạ trong rừng, nhưng miệng người chưa đủ. Ta muốn nghe chính từ kẻ trong cuộc. Nào, nói đi: rốt cuộc đã xảy ra chuyện gì?”",
+        "οNhân vật chính: “Bẩm Lý trưởng… rạng sáng hôm kia, tôi vác rìu vào rừng như thường lệ. Bất chợt nghe có ba người lạ nói chuyện. Họ nhắc đến chuyện làm Tức Mặc rối loạn, còn bảo rằng nếu làng này loạn thì cả thiên hạ cũng loạn theo… Tôi men lại gần nghe rõ thì bị chúng phát hiện. Chúng định giết ta để bịt miệng. Tôi chống trả… nhưng sức chẳng thấm vào đâu. May sao lúc đó lính gác tuần tới, chúng sợ bị lộ nên bỏ chạy. Tôi… ngất đi từ lúc ấy.”",
+        "οTrần Thế Lục: “Hừm… nói năng loạn nghịch, dám mưu tính ngay trong rừng làng này. Quả là chuyện chẳng lành.”",
+        "οNhân vật chính: “Lý trưởng… liệu có nên báo rộng ra cho dân biết, để họ cảnh giác?”",
+        "οTrần Thế Lục: “Không được. Địch muốn gieo loạn, ta lại loan tin, khác nào làm thay việc cho chúng. Dân quê nghe chuyện, trong lòng bất an, chỉ càng rối. Phải giữ yên thì mới trị yên.”",
+        "οNhân vật chính: “Vậy… chúng ta phải làm sao?”",
+        "οTrần Thế Lục: “Thân ngươi còn non, lại vừa thoát chết. Từ nay, hãy theo Trần Thế Sương ở sân tập mà học võ. Rèn thân mới giữ nổi mạng, có sức mới giữ nổi làng. Không chắc lần sau lính tuần sẽ đến kịp lúc.”",
+        "οNhân vật chính: “Vâng… tôi đã hiểu.”",
+        "οTrần Thế Lục: “Việc này, ta sẽ cho người âm thầm dò xét. Còn ngươi, trước hết hãy tự đứng vững đã. Tập trung theo thầy Sương mà luyện tập, có ngày chúng ta sẽ cần đến ngươi.”"
+      ],
+      "dialog_complete": [],
+      "targets": [
+        "οTìm gặp và nói chuyện với Lý trưởng Trần Thế Lục"
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 5,
+      "title": "Võ học làng Tức Mặc",
+      "description": "Gặp Trần Thế Sương ở sân tập, nhận côn tre, tỉ thí với Huy Phong.",
+      "accept_npc": "Trần Thế Lục (từ quest trước giao chỉ thị)",
+      "complete_npc": "Trần Thế Sương",
+      "dialog_accept": [
+        "οTrần Thế Sương: “À, hóa ra ngươi là cái thằng mà Lý trưởng gửi tới đây đấy à? Nhìn bộ dạng ngươi,  tay chân thì lỏng như bún… Nhưng thôi, đến sân này rồi thì không kể là ai, cứ phải tập.” ► Lựa chọn vũ khí khởi đầu",
+        "οTrần Thế Sương: “Cầm lấy cho chắc.”",
+        "οHuy Phong: “Ối giời ôi, nom kìa, mới cầm cái [Côn] mà đã lóng nga lóng ngóng như gà mắc tóc. Này ông thầy, để con thử cho hắn một chút đi. Không có ngã thì chẳng bao giờ biết cách đứng lên đâu.”",
+        "οTrần Thế Sương: “Được, nhưng nhớ tay chân có chừng mực. Ta muốn nó tỉnh, chứ không muốn vác xác về nhà thuốc.”",
+        "οHuy Phong: “Yên tâm, con chẳng đánh chết ai bao giờ. Nào, lại đây! Cầm chắc đi, đừng có buông rơi giữa sân, xấu mặt lắm đấy!”"
+      ],
+      "dialog_complete": [
+        "οHuy Phong: “Được đấy! Ta cứ tưởng ngươi chỉ biết vác rìu chặt củi. Ai ngờ cũng lì ra trò.”",
+        "οTrần Thế Sương: “Chân còn chao đảo, tay còn nặng, nhưng mắt đã biết nhìn. Từ nay ngươi cứ chăm luyện tập. Ngọc thô phải dũa mới thành đá quý. Ngươi còn phải rèn nhiều.”"
+      ],
+      "targets": [
+        "ο1) Tới sân tập. 2) Chọn vũ khí khởi đầu. 3) Combat với Huy Phong."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 6,
+      "title": "Bát chè xanh đầu ngõ",
+      "description": "Cùng Huy Phong ra quán chè đầu làng, nghe bà Đanh kể chuyện “người lạ từ rừng tre”.",
+      "accept_npc": "Huy Phong",
+      "complete_npc": "Bà Đanh",
+      "dialog_accept": [
+        "οHuy Phong: “Trông ngươi thở như trâu kéo cày rồi. Nghỉ chút đi. Đầu làng có hàng nước bà Đanh, chè xanh đặc lắm. Uống vào cho tỉnh táo, kẻo nằm vật ra đây thì mất vui.”",
+        "οNhân vật chính: “Ừ, đi thôi.”"
+      ],
+      "dialog_complete": [
+        "οBà Đanh: “Ối giời ôi, tập võ xong mà thở hồng hộc như vừa cày xong mấy sào ruộng thế kia. Nào, ngồi xuống đây, ta rót cho bát chè xanh. Chè mới hái sáng sớm, đắng đầu lưỡi mà ngọt hậu, uống xong tỉnh người ngay.”",
+        "οHuy Phong: “Khát khô cả cổ rồi, bà cứ rót cho đầy bát.  Tên này hôm nay mới tập cũng ra hồn, nhưng sức yếu, thở như bò kéo cày. Cho nó uống bát đặc vào kẻo ngã lăn ra.”",
+        "οNhân vật chính: “Cảm ơn bà. Chè thơm quá, mùi còn hăng hắc mà dễ chịu. Uống vào mát cả ruột gan.”",
+        "οBà Đanh: “Ấy, nói chứ mấy hôm nay ta cũng lắm điều ngờ lắm. Rạng sáng hôm kia, lúc dọn hàng sớm, ta thấy loáng thoáng vài bóng người lạ chạy vội ngang ngõ. Dáng vẻ hớt hải, nom như bị ai dí sau lưng. Từ hướng rừng tre mà ra đấy… Ta thì già mắt kèm nhèm, đâu có chắc, chỉ thấy lạ lắm thôi.”",
+        "οHuy Phong: “Bà thì suốt ngày thấy cái gì cũng thành chuyện. Người lạ đi ngang, ai cấm? Mà rừng tre thì người ta vẫn ra vào lấy củi, có gì đâu.”",
+        "οBà Đanh: “Ờ thì đúng là ai cũng có thể đi. Nhưng thử hỏi, rạng sáng tinh mơ, trời còn tối om, dân làng nào lại tha thẩn chạy như ma đuổi thế? Ta ngồi đây bao năm, khách buôn, người làng đi lại ta đều quen mặt cả. Mấy bóng đó, ta lạ. Thế thôi. Ta kể thế thôi chứ ta cũng chẳng dám đoán gì thêm.”",
+        "οNhân vật chính: “Ừ… cũng phải. Người lạ xuất hiện giờ ấy, quả là khó hiểu thật.”"
+      ],
+      "targets": [
+        "1.Ra quán nước. 2) Nói chuyện với bà Đanh."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 7,
+      "title": "Gáo nước giếng làng",
+      "description": "Ra giếng dội nước, định thần sau buổi tập và câu chuyện ở quán nước.",
+      "accept_npc": "(Auto - sau quán nước)",
+      "complete_npc": "(Auto - khi dội nước xong)",
+      "dialog_accept": [
+        "οHuy Phong: “Thôi nào, uống thế là đủ rồi. Nằm lì ở quán bà Đanh thì có ngày thành lão già nghe chuyện thiên hạ mất. Đi, ra giếng dội gáo nước cho tỉnh táo.”",
+        "οNhân vật chính: “Ừ…  người vẫn còn khó chịu, chắc phải dội cả gáo may ra mới nguôi.”",
+        "οBà Đanh: “Ờ, đi thì đi. Giếng làng nước trong, dội lên mát ruột. Nhưng nhớ đấy, chớ có soi xuống lâu quá, người ta bảo soi giếng lúc sẩm tối dễ thấy ma chứ chẳng thấy mặt mình đâu.”",
+        "οHuy Phong: “Lại bày chuyện hù dọa rồi. Thôi, bà cứ ngồi đếm khách đi, bọn tôi ra giếng cho mát.”"
+      ],
+      "dialog_complete": [
+        "οNhân vật chính: “Ơ… nghe gì không? Tiếng búa rèn. Mà sao hôm nay dồn dập thế?”",
+        "οHuy Phong: “Phải lò của bác Kim rồi. Ông ấy tính nóng như lửa, búa nện thế kia thì chắc đang bực chuyện gì. Hay qua xem thử?”.",
+        "οNhân vật chính: “Ừ, tiện đường thì ghé. Ít ra cũng học được thêm cái gì.”"
+      ],
+      "targets": [
+        "1) Ra giếng. 2) Dội nước lên mặt."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 8,
+      "title": "Búa lửa trong lò",
+      "description": "Ghé lò rèn, giúp ông Kim. Nghe ông bực bội về lời đồn “vét thuế”. Mở khóa sử dụng tính năng [Lò rèn]",
+      "accept_npc": "(Auto - sau Giếng làng)",
+      "complete_npc": "Trần Thế Kim",
+      "dialog_accept": [
+        "οTrần Thế Kim: “Đứng đấy làm gì? Muốn ngó thì ngó xa xa thôi, lại gần coi chừng lửa táp vào mặt đấy! Còn nếu tiện tay thì giúp ta chút.”",
+        "οHuy Phong: “Khéo vụng thì rụng cả tay. Cẩn thận đấy, không thì thầy thuốc Xuân Lang lại có việc băng bó cho ngươi.”"
+      ],
+      "dialog_complete": [
+        "οTrần Thế Kim: “Hầy… rèn đồ đã mệt, lại còn phải nghe thiên hạ lắm mồm. Cái chợ mấy bữa nay chỉ rặt một chuyện: triều đình sắp vét thêm thuế, thu nặng gấp đôi. Tai ta ù hết cả lên!”",
+        "οNhân vật chính: “Thuế… thật ạ? Sao tôi chưa nghe tin gì từ đình?”",
+        "οTrần Thế Kim: “Tin tức thì phải từ trên xuống! Nếu có lệnh, Lý trưởng phải là người báo đầu tiên. Thế mà chưa ai nói gì, ngoài chợ đã loạn cả lên. Toàn cái lũ ưa đồn thổi, chưa thấy giấy trắng mực đen đã hò hét loạn cả.”",
+        "οHuy Phong: “Nhưng dân chợ thì cũng khổ. Nghe loáng thoáng chuyện vét thuế thì ai mà chẳng sợ. Bán con cá, mớ rau còn run.”",
+        "οTrần Thế Kim: “Ừ, khổ thì khổ. Nhưng thử nghĩ xem, nếu thật, ta còn ngồi đây được chắc? Triều đình mà vét, lò rèn này cũng sập. Ta cũng chẳng tin. Chỉ tức là: ngày nào cũng nghe, nghe mãi cũng bực. Búa nặng thêm vì chuyện chợ búa, chứ không phải vì sắt.”",
+        "οNhân vật chính: “Vậy… có khi nên thưa lại với Lý trưởng, để ông ấy phân rõ thực hư. Chứ để dân cứ rì rầm, e là bất ổn.”",
+        "οTrần Thế Kim: “Ừ, phải. Ngươi thử đem việc ấy đến đình thưa với ông Lục xem sao. Ta ở đây búa nện, cãi nhau với chợ thì vô ích. Việc này, cần người tai nghe mắt thấy đi nói thì mới nên chuyện.”",
+        "οNhân vật chính: “Được rồi, tôi sẽ đi ngay. Tôi cũng muốn biết rõ thực hư, chứ nghe xong trong lòng cũng rối bời.”",
+        "οHuy Phong: “Thế thì tốt. Nghe lời bác Kim cũng phải. Việc lớn phải đưa ra đình, chứ ngồi mà bàn thì chỉ thêm rối.”",
+        "οTrần Thế Kim: “Ừ, đi đi. Còn ta lo cái lò này. Tin đồn có thật hay không, rồi cũng sẽ lòi mặt chuột thôi.”"
+      ],
+      "targets": [
+        "1.Đến lò rèn.",
+        "2.Giúp ông Kim. ► Mở khóa tính năng [Lò rèn]",
+        "3.Nghe ông nói về lời đồn."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 9,
+      "title": "Lời đồn chợ quê",
+      "description": "Quay lại đình, báo cho Lý trưởng chuyện lời đồn “vét thuế” mà Trần Thế Kim kể. Nhận chỉ thị phải ra chợ dò hỏi, nghe đủ hai phía.",
+      "accept_npc": "(Auto - sau khi rời lò rèn)",
+      "complete_npc": "Lý trưởng Trần Thế Lục",
+      "dialog_accept": [
+        "οTrần Thế Lục: “Ngươi quay lại sớm thế. Có chuyện gì mà vào đây?”",
+        "οNhân vật chính: “Bẩm Lý trưởng, tôi vừa qua lò rèn của bác Kim. Ông ấy tức lắm, bảo chợ mấy bữa nay toàn rộ lên lời đồn triều đình sẽ vét thêm thuế nặng. Nghe nhiều, ai cũng hoang mang. Ông Kim thì không tin, nhưng tai cứ phải nghe, đâm ra bực.”",
+        "οTrần Thế Lục: “Hừ… thuế má là việc trọng. Có tăng giảm thì cũng phải từ triều đình, qua phủ, rồi mới xuống tới làng. Sao dân ngoài chợ lại biết trước ta? Rõ ràng có kẻ gieo lời xấu để xao lòng người.”",
+        "οNhân vật chính: “Tôi cũng nghĩ vậy, có khi lại liên quan đến chuyện hôm trước. Nhưng nếu cứ để lời đồn lan, e là trong làng bất an.”",
+        "οTrần Thế Lục: “Đem lính đi rầm rộ tra xét lúc này chưa chắc đã hay. Địch muốn dân loạn, ta lại làm dân xôn xao thì khác nào mắc mưu. Phải nhẹ tay mà khéo.”"
+      ],
+      "dialog_complete": [
+        "οTrần Thế Lục: “Ngươi vừa trải qua chuyện ở rừng, nay lại tận tai nghe ở lò rèn. Ngươi là kẻ ít ai để ý, dễ len lỏi. Vậy ngươi thử ra chợ, khéo léo mà hỏi. Đừng để lộ ý dò xét. Hỏi cho đủ hai phía: kẻ tin, kẻ không tin. Rồi về đây báo lại cho ta.”",
+        "οNhân vật chính: “Chà, đây thực sự là một trách nhiệm lớn với tôi.”",
+        "οTrần Thế Lục: “Ngươi chỉ cần lắng nghe. Người thật sự bực tức thì tự khắc sẽ tuôn ra. Người không tin thì sẽ có cách gạt đi. Việc của ngươi là ghi nhớ, chứ không phải tranh cãi. Cứ bình thản, như thể trò chuyện ngoài chợ thôi.”",
+        "οNhân vật chính: “Được thôi, tôi biết mình cần phải làm gì rồi.”",
+        "οTrần Thế Lục: “Lời đồn như lửa âm trong rơm, gió nhẹ cũng bùng. Phải nắm cho rõ, rồi dập ngay, kẻo muộn thì cháy lan khắp làng. Ngươi đi đi."
+      ],
+      "targets": [
+        "1.Quay lại đình và nói chuyện với Lý trưởng."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 10,
+      "title": "Dò chuyện ở chợ 1 – Lời thuế nặng trĩu",
+      "description": "Ra chợ Tức Mặc, dò hỏi chuyện từ người dân.",
+      "accept_npc": "(Auto - sau chỉ thị của Lý trưởng)",
+      "complete_npc": "Trần Văn Cẩn",
+      "dialog_accept": [],
+      "dialog_complete": [
+        "οNhân vật chính: “Chào bác Cẩn, cá sáng nay nhiều thế. Cá rô này còn quẫy khỏe lắm, chắc mới kéo từ đầm về?”",
+        "οTrần Văn Cẩn: “Ừ, đêm qua đi thả lưới, giờ mang ra bán. Cá làng mình nuôi chứ đâu, thịt chắc vô cùng.”",
+        "οNhân vật chính: “Đúng thật, vảy sáng lấp lóa. Bác cho tôi dăm con nhỏ về kho ăn cơm. À… mà dạo này chợ đông vui ghê, ai cũng nói cười, xôn xao đủ chuyện.”",
+        "οTrần Văn Cẩn: “Xôn xao gì đâu, toàn cái chuyện làm dân rầu mặt. Ngươi chưa nghe à? Họ bảo triều đình vét thuế nữa kìa.”",
+        "οNhân vật chính: “Vét thuế ạ? Tôi chỉ nghe loáng thoáng, chưa rõ thế nào. Người thì bảo có, người thì gạt đi.”",
+        "οTrần Văn Cẩn: “Có chứ! Cả chợ nói ầm ầm cả tuần nay. Nếu thật thì phen này dân đen chỉ còn nước bán nhà, bán trâu. Ta buôn cá mà còn thấy lo, huống chi nông dân gánh sưu nặng nề.”",
+        "οNhân vật chính: “Nghe bác nói cũng thấy sợ thật. Nhưng… bác có chắc không? Hay chỉ là tin gió thôi?”",
+        "οTrần Văn Cẩn: “Chắc với không chắc! Ở cái xứ này, trên bảo thì dưới nghe. Lý trưởng thì cũng chỉ biết truyền lại thôi. Hầy, ngươi còn trẻ, chưa gánh sưu nên chưa thấy cái cảnh người ta bán thóc trả thuế đâu.”",
+        "οNhân vật chính: “Tôi hiểu rồi. Nghe bác kể mà tôi cũng rùng mình.”"
+      ],
+      "targets": [
+        "1.Nói chuyện với Trần Văn Cẩn"
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 11,
+      "title": "Dò chuyện ở chợ 2 – Tiếng đồn tiếng chợ",
+      "description": "Ra chợ Tức Mặc, dò hỏi chuyện từ người dân",
+      "accept_npc": "(Auto)",
+      "complete_npc": "Mụ Còng",
+      "dialog_accept": [],
+      "dialog_complete": [
+        "οNhân vật chính: “Chào mụ Còng, rau muống mớ này xanh mướt thế. Lá còn đẫy nhựa, chắc mới cắt sáng nay hả mụ?”",
+        "οMụ Còng: “Ừ, sáng sớm ra ruộng cắt đấy. Nước mưa đêm qua ngấm vào, rau xanh hơn thường ngày. Làng này chỉ cần ruộng còn nước, rau còn mọc, là ta còn bán được.”",
+        "οNhân vật chính: “Đúng là rau vườn mình khác hẳn. Mụ bán bao năm rồi, chắc chợ này chuyện gì cũng qua tai, mắt.”",
+        "οMụ Còng: “Thì tai già này ngày nào chả nghe. Người ta nói lắm, nhưng không phải cái gì cũng đáng tin. Cứ vài bữa lại có chuyện đồn nhảm, làm dân hoang mang.”",
+        "οNhân vật chính: “Vâng, tôi cũng nghe loáng thoáng mấy lời về sưu thuế. Nhưng chẳng biết thực hư ra sao.”",
+        "οMụ Còng: “À cái chuyện thuế má ấy hả? Nhảm nhí! Triều đình vừa mới tha sưu năm ngoái, người dân mới được thở một hơi. Nay ai đời lại quay ra vét tiếp? Toàn miệng lưỡi kẻ xấu, muốn làm làng này rối loạn.”",
+        "οNhân vật chính: “Nhưng mà… người ngoài chợ nhiều kẻ nói có lý …”",
+        "οMụ Còng: “Lý hay không lý thì triều đình lo. Dân như ta chỉ lo cấy cày, đóng góp đúng lệnh, đúng bổn phận. Bao năm nay, nghe tin đồn thì nhiều, mấy lần thành thật? Đồn càng to, càng vô lý. Chỉ tội cho những đứa nhẹ dạ tin theo, rồi hoang mang, bỏ cả việc ruộng đồng.”",
+        "οNhân vật chính: “Mụ nói cũng phải… không chắc mà loan ra thì hỏng chuyện.”",
+        "οMụ Còng: “Ừ, nhớ lấy. Tai nghe thì cứ để tai, đừng để miệng nói ra. Dân quê có cái gì ngoài ruộng với rau đâu. Để tâm nhiều chỉ thêm bệnh.”"
+      ],
+      "targets": [
+        "οNói chuyện với mụ Còng"
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 12,
+      "title": "Dò chuyện ở chợ 3 – Mùi mắm mùi đời",
+      "description": "Ra chợ Tức Mặc, dò hỏi chuyện từ người dân",
+      "accept_npc": "(Auto)",
+      "complete_npc": "Mụ Mướp",
+      "dialog_accept": [],
+      "dialog_complete": [
+        "οNhân vật chính: “Chào mụ Mướp, mắm hôm nay nặng mùi quá, chắc để ủ kỹ lắm đây. Cho tôi xin ít về kho cá.”",
+        "οMụ Mướp: “Ha, mắm mà không nặng thì đâu còn là mắm! Người ta ăn mắm là ăn cái mùi, cái vị nó thấm vào cơm. Cứ lấy một tí thôi thì gọi là hết nồi cơm đấy.”",
+        "οNhân vật chính: “Nghe mụ nói mà tôi cũng thèm. Mà dạo này chợ đông, người nào người nấy cũng bàn tán chuyện… chẳng mấy khi yên.”",
+        "οMụ Mướp: “Lại cái vụ thuế chứ gì. Cả chợ ai mà chẳng nghe. Người thì bảo triều đình vét thêm cho đủ chi tiêu. Hầy, ta nghe mà lo hết ruột gan. Lão chồng ta còn tính: phen này chắc phải bán nốt con trâu già mới đủ nộp.”",
+        "οNhân vật chính: “Đến mức ấy thật sao? Biết đâu chỉ là tin thổi phồng?”",
+        "οMụ Mướp: “Tin thì tin, mà không tin thì cũng phải lo. Bọn trên đầu nói một câu, dưới này gồng cả đời. Ngươi còn trẻ, chưa nếm cảnh gom từng đấu gạo để nộp, mới thấy nó xa. Chứ thử như ta, một năm đóng sưu xong, thóc chẳng còn bao nhiêu. Năm nào cũng chật vật, giờ mà vét thêm nữa thì… hầy, chắc ta chỉ còn cái xác.”",
+        "οNhân vật chính: “Mụ nói vậy, tôi cũng thấy sợ.”",
+        "οMụ Mướp: “Sợ thì phải! Đừng tưởng người chợ chỉ biết buôn bán. Chuyện không phải tự dưng. Có khói thì mới có lửa. Có người đưa cho ta xem rồi, giấy trắng mực đen của triều đình rõ ràng.”"
+      ],
+      "targets": [
+        "οNói chuyện với mụ Mướp"
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 13,
+      "title": "Dò chuyện ở chợ 4 – Mảnh giấy miếng trầu",
+      "description": "Ra chợ Tức Mặc, dò hỏi chuyện từ người dân",
+      "accept_npc": "Trần Thị Quýt",
+      "complete_npc": "Trần Thị Quýt",
+      "dialog_accept": [
+        "οNhân vật chính: “Chào chị Quýt, cau têm đều quá. Cho tôi ít lá trầu với mấy quả cau… để thắp hương cha mẹ ở nhà.”",
+        "οTrần Thị Quýt: “Ờ… cũng quý cho ông bà nhà cậu. Người ta bây giờ mải lo miếng ăn, mấy ai còn nhớ hương khói. Cậu còn trẻ mà giữ được nếp xưa, hiếm lắm. Trầu cau này mà đặt lên mâm hương, nhìn cũng ấm lòng người khuất.”",
+        "οNhân vật chính: “Ở một mình, nhiều lúc chỉ mong có làn khói hương cho đỡ lạnh lẽo. Cơm nước thì sao cũng được, nhưng thiếu hương khói thì thấy trống trải.”",
+        "οTrần Thị Quýt: “Ừ… có khói hương là còn chỗ dựa. Bằng không, nhà cửa cũng lạnh tanh. Ta buôn ở chợ bao năm, thấy nhiều cảnh… người bỏ quên bàn thờ, con cái chẳng đoái hoài, nghĩ mà thương.”",
+        "οTrần Thị Quýt: “Mà gần đây, cậu có nghe người ta nói gì không? Ở chợ này, người ta nói nhiều lắm, lời ngay lời sai lẫn lộn, dễ bị cuốn lắm đó.”",
+        "οNhân vật chính: “Vâng… tôi cũng nghe nhiều người bàn về thuế má. Người thì quả quyết triều đình vét, người lại gạt đi. Tôi chẳng biết đâu mà lần.”",
+        "οTrần Thị Quýt: “Ở chợ này, tai ta ngày nào cũng ù lên vì nghe thiên hạ cãi cọ. Người thì thề sống chết là triều đình vét thuế, kẻ thì cười khẩy bảo bịa đặt. Nghe riết, lòng ta cũng loạn cả.”",
+        "οNhân vật chính: “Tôi thì nghĩ… nếu thật, ắt đình đã báo. Chợ búa nhiều miệng, gió thổi kiểu gì cũng hóa thành bão. Tin theo rồi nói lại, chỉ thêm rối.”",
+        "οTrần Thị Quýt: “Ờ hầy… nghe người ta nói vậy mà cậu cũng chẳng động lòng gì à? Người thì sợ xanh mặt, còn cậu… cứ thản nhiên.”",
+        "οNhân vật chính: “Không phải thản nhiên, mà là sợ mình tin sai. Đợi đình có giấy có lời, khi ấy mới lo cũng chưa muộn.”",
+        "οTrần Thị Quýt: “Nói thật với cậu… sáng sớm nay có gã lạ ghé mua cau. Khi dọn hàng ta thấy rơi cái tờ giấy này. Ta chẳng biết chữ, nhưng từng thấy giấy quan dán ở đình. Giấy này có dấu đỏ như quan, nhưng nó lại thì mỏng sần, dúm dó, lại in cái dấu đỏ nhòe nhoẹt. Nhìn đã thấy lạ.”"
+      ],
+      "dialog_complete": [
+        "οNhân vật chính: “Đúng là chẳng giống giấy yết thị. Thiếu ngày tháng, chẳng ghi nơi niêm yết, dấu đỏ lại mờ. Lạ thật.”",
+        "οTrần Thị Quýt: “Đấy. Ta cũng thấy gai người. Định đốt đi mà sợ… lỡ là thật thì thành mang tội. Giữ lại thì lo, đàn bà buôn chợ ôm giấy quan trong người… lỡ bị tra hỏi, ai tin ta trong sạch?”",
+        "οTrần Thị Quýt: “Cậu cầm lấy. Nhưng nhớ, đừng nói là ta đưa. Ta chẳng dám lên đình, sợ mang tiếng tung tin. Nếu cậu muốn cho rõ, thì… thử mang qua ông Kiến hỏi. Ông ấy buôn rộng, nghe nhiều, biết đường. Rồi sau đó… cậu nộp thẳng cho Lý trưởng. Miệng cậu kín, ta mới dám gửi.”",
+        "οNhân vật chính: “Tôi hiểu rồi. Chị để tôi lo liệu.”"
+      ],
+      "targets": [
+        "Nói chuyện với Trần Thị Quýt"
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 14,
+      "title": "Thương nhân mấu chốt",
+      "description": "Mang thư nặc danh tới nhà/sạp Trần Đăng Kiến. Ông bác bỏ lời đồn, rồi soi kỹ thư, kết luận giấy và mực lạ, chắc có bàn tay ngoài. Khuyên phải báo ngay Lý trưởng.",
+      "accept_npc": "(Auto - sau khi nhận thư từ Trần Thị Quýt)",
+      "complete_npc": "Trần Đăng Kiến",
+      "dialog_accept": [
+        "οNhân vật chính: “Chào bác Kiến. Sạp đông khách quá, đúng là người ta bảo, đi một vòng chợ chi bằng ghé chỗ bác Kiến.”",
+        "οTrần Đăng Kiến: “Ờ thì, ta buôn cho đủ thôi. Muối gạo, nồi niêu, vải vóc… có gì đổi được thì ta bán. Để bà con khỏi chạy lên tận chợ phủ, mệt người.”",
+        "οNhân vật chính: “Chợ đông thật, nhưng nghe riết chỉ toàn chuyện thuế má. Người thì sợ, người thì gạt. Bác đi nhiều, hẳn nghe nhiều hơn tôi.”",
+        "οTrần Đăng Kiến: “Hầy, lời chợ thì gió. Nếu có thật, đã phải từ phủ xuống đình, trống mõ gọi dân, bô lão đọc giữa sân. Ta đi bến sông, chợ phủ, chưa thấy ai nhắc. Mà mấy bận như này, toàn tin vớ vẩn, hù cho dân rối trí.”",
+        "οNhân vật chính: “Tôi cũng mong thế… nhưng bác xem thử cái này đã.”",
+        "οTrần Đăng Kiến: “Cái gì? Đừng giơ cao, kẻo lắm con mắt dòm.”",
+        "οNhân vật chính: “Trong này có kẹp một mảnh giấy. Tôi nhặt được, chưa dám đưa ai xem.”"
+      ],
+      "dialog_complete": [
+        "οTrần Đăng Kiến: “…Ờ hầy. Giấy này… coi thì ra dáng giấy quan, mà sờ vào thì khác. Nhàu dúm, mỏng lét. Dấu đỏ in lệch, nhòe nhoẹt. Câu chữ thì nửa mùa, lối văn chắp vá. Nói chiếu theo mà không ghi ngày, cũng chẳng chỗ niêm yết. Yết thị thật không ai làm vậy.”",
+        "οNhân vật chính: “Thế… là giả bác nhỉ?”",
+        "οTrần Đăng Kiến: “Ừ. Ta vừa ở bến về, lái đò bảo làng bên sáng nay cũng nhặt được một tờ giống hệt. Bên Thượng Lỗi cũng rộ lên. Một sớm mà rải khắp, rõ ràng là kẻ ngoài tung ra. Dân mình nghèo chữ, nghèo giấy, ai bày nổi trò dấu má như thế này?”",
+        "οNhân vật chính: “Vậy… tôi nên làm gì?”",
+        "οTrần Đăng Kiến: “Cất kỹ đi, rồi đợi xế bóng, đi ngõ sau mà vào đình, nộp thẳng cho ông Lục. Gặp ai hỏi, nói trầu cau biếu lão Lục, đừng nhắc nửa lời về tờ giấy. Nhớ lấy, lỡ ra là hỏng.”",
+        "οNhân vật chính: “Tôi hiểu rồi. Đa tạ bác.”",
+        "οTrần Đăng Kiến: “Ừ. Nhớ cho rõ: lệnh thật thì trống mõ gọi dân ra sân đình, giấy dán ngay cột đình, không bao giờ xuất hiện ở quán chợ. Đấy mới là dấu chắc. Còn mấy thứ này… chỉ là gió độc gieo hoang mang thôi.”"
+      ],
+      "targets": [
+        "1.Mang thư đến nhà/sạp Trần Đăng Kiến.",
+        "2.Nói chuyện và nghe ông phân tích lời đồn."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 15,
+      "title": "Ba chiếc phong thư",
+      "description": "Trình lại thư nặc danh và kết luận của Trần Đăng Kiến cho Lý trưởng. Nhận từ ông ba phong thư mời họp kín, gửi cho Thế Sương, Xuân Lang, và lão Trần Tri.",
+      "accept_npc": "(Auto - sau khi rời nhà/sạp Trần Đăng Kiến)",
+      "complete_npc": "Lý trưởng Trần Thế Lục",
+      "dialog_accept": [
+        "οNhân vật chính : “Bẩm ông Lục… tôi có chuyện gấp, xin vô trình.”",
+        "οTrần Thế Lục: “Ờ, là cậu hả? Trưa nắng chang chang mà mò tới đình, hẳn chẳng phải chuyện chơi. Vào đi.”",
+        "οNhân vật chính: “Tôi… nhặt được thứ này ngoài chợ. Ban đầu con sợ, chẳng dám mở. Sau đem qua bác Kiến coi, ông ấy bảo giả. Con mới dám đem tới đây.”",
+        "οTrần Thế Lục: “Cậu biết… ôm cái này vô đình là gánh thế nào không? Một khi ta nhận, là coi như cậu dính việc lớn rồi đấy.”",
+        "οNhân vật chính: “…Tôi biết nặng. Nhưng giấu thì nó đi thì còn nặng hơn, nên tôi liều mang tới.”",
+        "οTrần Thế Lục: “Hầy… coi nè. Giấy mỏng thế này, dúm dó như lá chuối khô. Dấu đỏ đóng lệch, nhòe cả mực. Chữ thì ghi ‘yết thị’ mà chẳng có ngày, chẳng lạc khoản. Giấy quan thật phải qua tay ta, rồi dán ngay cột đình. Đâu có chuyện rơi rớt ở ngoài kia.”",
+        "οTrần Thế Lục: “Có ai thấy cậu lượm không? Nói cho thật.”",
+        "οNhân vật chính: “Thưa… không. Người ta xúm bàn, chuyền tay. Tôi thừa lúc họ xao nhãng mà nhặt, giấu ngay trong gói trầu.”"
+      ],
+      "dialog_complete": [
+        "οTrần Thế Lục:“…Chuyện lần trước của ngươi đã lớn, ta cứ nghĩ tin đồn cũng chỉ là truyền miệng, nay chúng dám cả gan giả dấu triều đình. Thật không thể chấp nhận được.”",
+        "οTrần Thế Lục: “Nghe cho kỹ. Việc này tuyệt đối không để lọt. Cậu cầm ba phong thư này: một trao ông Thế Sương, một cho thầy thuốc Xuân Lang, một cho lão Tri. Cứ theo ngày trong đó, tụ họp ở nhà thuốc. Nhớ là với người khác thì kín chuyện như bưng, không được hé nửa lời.”"
+      ],
+      "targets": [
+        "1.Đến đình, trình thư cho Lý trưởng.",
+        "2.Nhận ba phong thư mời họp."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 16,
+      "title": "Giao thư 1 - Hơi thở an tĩnh",
+      "description": "Mang thư của Lý trưởng đến cho Trần Thế Sương. Ông hướng dẫn ngồi tĩnh tâm, thiền.",
+      "accept_npc": "(Auto - sau khi nhận 3 phong thư)",
+      "complete_npc": "Trần Thế Sương",
+      "dialog_accept": [
+        "οNhân vật chính: “Ông Lục dặn tôi mang tận tay cho ông.”",
+        "οTrần Thế Sương: “Mặt mày cậu tái đi, mắt còn run. Giữ thư chưa kịp ấm tay đã lộ vẻ lo. Việc kín mà để lộ thế, khác nào hỏng.”",
+        "οNhân vật chính: “…Tôi lo sợ lỡ sai, nên lòng chẳng yên.”",
+        "οTrần Thế Sương: “Hầy… lòng rối thì bước run. Ngồi xuống đây.”",
+        "οTrần Thế Sương: “Hít sâu vô, coi như hút gió sớm vào bụng. Giữ lại chút, như nước mưa đọng trong chum. Rồi thở ra chậm, cho nó lùa hơi nóng ra ngoài. Làm lại. Đừng vội.”"
+      ],
+      "dialog_complete": [
+        "οTrần Thế Sương: “Thân trẻ mà bụng nóng vội, hơi chẳng ở yên.”",
+        "οTrần Thế Sương: “Tâm có an thì thân mới yên ổn. Hôm nay ngươi đã bị cuốn vào chuyện này, ngày sau sẽ còn nhiều chuyện phải lo. Cố mà giữ cho mình cái định, cái hơi thở. Tre còn biết nghiêng theo nhịp gió, huống chi người.”",
+        "οTrần Thế Sương: “Đủ rồi. Thư ta nhận. Cậu đi cho kịp.”"
+      ],
+      "targets": [
+        "1.Đến sân tập gặp Trần Thế Sương.",
+        "2.Trao thư mời họp.",
+        "3.Ngồi xuống, tập thiền theo lời dạy."
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 17,
+      "title": "Giao thư 2 – Thỏ xào và lá thuốc",
+      "description": "Đưa thư cho Xuân Lang. Ra vườn hái lá, bứt lá chuối, bắt thỏ. Học chế thuốc cầm máu, ăn món thỏ xào thảo dược của Quỳnh.",
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [
+        "οNhân vật chính: “Chào thầy Xuân Lang. Ông Lục dặn tôi mang phong thư này tới tận tay thầy.”",
+        "οTrần Xuân Lang: “Đưa đây cho ta.”",
+        "οTrần Xuân Lang: “Nhưng ngươi, còn trẻ, lại bị cuốn vào việc này… Đường phía trước dài lắm.”",
+        "οNhân vật chính: “Thầy… tôi nghe mà cũng lo. Nhưng ông Lục giao thì tôi phải làm thôi.”",
+        "οTrần Xuân Lang: “Ờ, người trẻ thì phải gánh phần người trẻ. Có vậy mới nên chuyện.”",
+        "οTrần Xuân Quỳnh: “Thầy ơi, trong hũ thuốc cầm máu còn chút xíu, thiếu lá gấu rồi!”",
+        "οTrần Xuân Lang: “Này, nếu có tiện thì ngươi ra vườn bứt cho ta ít lá gấu, thêm vài tàu chuối non. Ta bày cách làm thuốc luôn để sau này hoạn nạn có cách tự cứu lấy thân. Cả thêm vài con thỏ nữa, ta bảo Quỳnh làm cho ngươi một phần thịt để ăn cho lại sức, chặn đường tới đây ngươi sẽ vất vả nhiều.”"
+      ],
+      "dialog_complete": [
+        "οTrần Xuân Lang: “Nhanh thế đã về rồi cơ à? Tốt lắm, đưa cho ta.”",
+        "οTrần Xuân Lang: “Đập nhỏ rễ này, trộn với cỏ gấu, gói trong lá chuối. Bị thương thì chườm vào, máu sẽ dừng. Nhớ kỹ, đơn giản vậy thôi, Thuốc nam không khó, cái chính là chịu để ý.”",
+        "οTrần Xuân Quỳnh: “Còn đây là phần thịt thỏ ban nảy, tôi có bỏ thêm ít cỏ thuốc, nên thơm mà hơi đắng. Ăn vô người khỏe, đầu óc cũng tỉnh.”",
+        "οTrần Xuân Lang: “Được rồi, lấy sức xong rồi mau lo chuyện còn lại đi.”"
+      ],
+      "targets": [
+        "οGiao thư cho Trần Xuân Lang",
+        "οThu thập lá cỏ gấu và lá chuối",
+        "οBắt thỏ",
+        "οĂn món thỏ xào thảo dược"
+      ],
+      "notes": [],
+      "extra_fields": {}
+    },
+    {
+      "id": 18,
+      "title": "Giao thư 3 – Gậy già chờ tay",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Mang thư mời họp kín đến cho lão Trần Tri.",
+        "accept NPC: (Auto – sau khi nhận 3 thư)",
+        "complete NPC: Lão Trần Tri",
+        "dialog accept",
+        "οNhân vật chính: “Chào lão Tri. Ông Lục dặn tôi mang thư này tới tận tay lão.”",
+        "οLão Trần Tri: “Ờ, cám ơn cậu. Già rồi, mắt kèm nhèm, đọc thư cũng mất hơi lâu… khoan đã… ừm.”",
+        "οLão Trần Tri: “Cái gậy của ta cũng có tuổi rồi, chuyện lớn thế này sợ nó không theo được xa. Cái thân già này không có gậy thì như cua cụt càng, ra đình coi bộ khó quá.”",
+        "οNhân vật chính: “Lão còn phải đi họp, gậy lại thế này… Vậy biết làm sao?”",
+        "οLão Trần Tri: “Ờ thì… cũng chỉ biết ngồi đây than. Gậy này theo ta mấy chục năm, giờ nó chịu thua. Đáng lẽ ta tự lo được, mà chân run tay mỏi rồi.”",
+        "οNhân vật chính: “Nếu cần, tôi thử chạy sang nhà ông Mục xem sao. Ông ấy khéo tay nghề gỗ, biết đâu làm cho lão cái gậy mới.”",
+        "οLão Trần Tri: “Ừ, cũng phải. Thằng Mục xưa nay làm chắc. Nhưng nhớ dặn nó… kiếm được khúc lim nhỏ nào thì tốt. Chắc thì già này mới dám bước ra đình, không thì đi giữa đường ngã thì mất mặt lắm.”",
+        "dialog complete",
+        "οNhân vật chính: “Được, để tôi ghé ông Mục thử bàn. Tôi cũng mong lão có gậy chắc để chống đi cho yên bụng.”",
+        "οLão Trần Tri: “Ờ, nhờ cậu vậy. Già này chẳng dám sai bảo, chỉ mong còn chống được cái thân đi họp với anh em bô lão. Có cậu trẻ giúp, ta cũng yên dạ phần nào.”",
+        "οNhân vật chính: “Lão đừng lo, tôi sẽ cố chạy cho kịp.”",
+        "target",
+        "οĐến nhà lão Trần Tri.",
+        "οTrao thư."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 19,
+      "title": "Lời đồn rừng tây",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Tới xưởng gỗ, hỏi chỗ có gỗ lim nhỏ phù hợp.",
+        "accept NPC: (Auto)",
+        "complete NPC: Trần Đăng Mục",
+        "dialog accept",
+        "οNhân vật chính: “Chào bác Mục, tôi vừa ở bên lão Tri qua. Lão bảo cái gậy cũ mục hết rồi, chống vài bước là gãy. Nên tôi sang nhờ bác giúp làm cho lão cái gậy mới.”",
+        "οTrần Đăng Mục: “Ờ… già Tri vẫn còn ương cứng lắm. Gậy nứt từ đời nào cũng ôm khư khư, tới lúc gãy rắc rồi mới nhờ. Nhưng mà… gậy lim thì chắc, còn giờ lim trong xưởng này thì sạch trơn.”",
+        "οNhân vật chính: “Không còn khúc nào dư sao, bác?”",
+        "οTrần Đăng Mục: “Gỗ tạp thì nhiều, chỗ nào cũng có. Nhưng lim thì hiếm lắm. Đâu ngoài bìa rừng phía tây còn mấy cây nhỏ. Chỉ tội… người ta đồn ở đó có ma lai, nên ai cũng ngán, chẳng dám bén mảng.”",
+        "οNhân vật chính: “Ma lai thật hả bác? Tôi nghe bác nói thôi, chưa rõ thế nào.”",
+        "οTrần Đăng Mục: “Thật giả thì ai mà biết. Ta thì xưa nay chỉ tin vào mắt mình. Nhưng cái chân này mấy bữa nay sưng, bước còn nhói, có muốn lội vô rừng cũng chịu. Mà bọn người làm, nghe tin đồn xong cũng đâu dám thử vào.”",
+        "οNhân vật chính: “Nếu tôi liều thử, lấy được khúc lim mang về… bác có chịu làm cho lão Tri không?”",
+        "οTrần Đăng Mục: “Ờ, mang về được thì ta làm ngay. Đầu bịt sắt, thân chắc, lão Tri có chống thì cũng khỏi lo gãy.”",
+        "οNhân vật chính: “Tôi nghe bác nói, cũng hơi rợn. Nhưng nếu không có gậy, lão Tri làm sao mà tới đình. Tôi sẽ thử.”",
+        "dialog complete",
+        "οTrần Đăng Mục: “Khá đấy. Mà về tin đồn kia, việc âm dương thì ta không rành. Ngươi muốn yên tâm thì qua hỏi bà Mắm. Bả tuy mê tín, nhưng cũng rành mấy cái mẹo của ông bà xưa nay.”",
+        "οTrần Đăng Mục: “Lim mà mang về được, ta hứa làm cho ra cây gậy chắc, già Tri chống mà cũng vênh mặt với thiên hạ.”",
+        "target",
+        "οTới xưởng gỗ.",
+        "οTrò chuyện với Trần Đăng Mục."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 20,
+      "title": "Tìm mẹo trấn âm",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Hỏi bà Mắm mẹo tránh tà khí khi vào rừng tây.",
+        "accept NPC: (Auto)",
+        "complete NPC: Bà Mắm",
+        "dialog accept",
+        "οNhân vật chính: “Bà Mắm, tôi nghe người ta kháo… rìa rừng tây có chuyện lạ. Bà hay để ý mấy chuyện tâm linh, bà có nghe thấy gì không?”",
+        "οBà Mắm: “Hầy, cậu trẻ này… hỏi chi toàn chuyện gở. Làng này ai chả xì xào. Người thì bảo nghe tiếng cười the thé, người thì thề thấy bóng đen bay là là mặt đất. Nghe mà dựng tóc gáy.”",
+        "οNhân vật chính: “Thế bà tin là có thật sao?”",
+        "οBà Mắm: “Tin với chả không tin… Ngày trước, có thằng con ông thợ mộc… coi thường, chẳng chịu nghe, cứ vác rìu vô rừng một mình. Người ta thấy nó về, mắt lạc thần, người như mất hồn. Nằm một đêm, sáng ra lạnh ngắt. Từ đó… chẳng ai dám bước chân vô mà tay không. Già đây xưa giờ cũng hay gặp, mấy chuyện thế này nên tránh, có kiêng có lành cậu ơi.”",
+        "οNhân vật chính: “Tôi có việc phải vào. Nhưng nghe đồn vậy, lòng cũng không yên.”",
+        "οBà Mắm: “Thân trai mà đi chỗ âm u đó, gan có to mấy cũng dễ bị hớp vía. Người ta bảo, ma quỷ nó ưa hơi lạnh, gặp người yếu bóng, nó lùa cái là đổ bệnh ngay.”",
+        "οNhân vật chính: “Bà có biết cách nào… cho yên bụng hơn không?”",
+        "οBà Mắm: “Ờ… cũng có mẹo truyền lại của ông bà thôi. Không phép thánh gì đâu. Người ta nói ma thì âm, muốn át nó thì phải mang thứ cực dương theo người.”",
+        "οNhân vật chính: “Cực dương là thứ gì?”",
+        "οBà Mắm: “Dân gian tin rằng… trứng gà vừa đẻ, còn nóng hổi, với lại… nước tiểu trẻ con. Nghe thì dơ, mà nó là dương khí thuần khiết.”",
+        "οBà Mắm:“Trứng gà ở đây thì thiếu gì. Ra sân đá gà mà tìm thằng Trần Kê, nhà nó nuôi cả bầy gà chọi, ổ nào chả có. Còn trẻ con… ờ, ra bờ sông hỏi thằng cu Lỳ. Nó còn nhỏ, suốt ngày ngồi câu cá, vô tư lắm. Nó là cháu ta, cứ ra nói với nó là ta bảo ngươi, nó sẽ biết thôi.”",
+        "dialog complete",
+        "οNhân vật chính: “Tôi cảm ơn bà. Tôi sẽ nhớ lời dặn.”",
+        "οBà Mắm: “Ơn nghĩa gì. Ta chỉ nói cái ta nghe. Còn đi hay không, là gan cậu.”",
+        "target",
+        "οĐến sạp bà Mắm.",
+        "οHỏi chuyện bà Mắm."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 21,
+      "title": "Mồi cá bên sông",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Ra bờ sông gặp cu Lỳ.",
+        "accept NPC: (Auto)",
+        "complete NPC: Cu Lỳ",
+        "dialog accept",
+        "οNhân vật chính: “Lỳ, hôm nay được con nào chưa?”",
+        "οCu Lỳ: “Được ba con rô rồi. Tối nay mẹ kho chắc hết sạch cơm.”",
+        "οNhân vật chính: “Khá thật. Ngồi cả buổi, không chán à?”",
+        "οCu Lỳ: “Không. Ngồi coi phao cũng vui. Ngồi đây vừa mát vừa yên tĩnh, ngồi lâu có mắc thì đi thẳng ra sông luôn cũng tiện nữa.”",
+        "οNhân vật chính: “Chuyện là... bà Mắm bảo ta sang đây tìm ngươi để...”",
+        "οCu Lỳ: “Ơ kìa,... Ta hiểu rồi, mà bác cũng tin mấy chuyện đó à? Nhưng thôi, bác muốn thì được. Nhưng bác ngồi đây đi, giờ ta chưa buồn đi.”",
+        "dialog complete",
+        "οĐây, lấy cái ống đựng mồi này mà giữ, coi chừng đổ ra kẻo thối um nhé.",
+        "target",
+        "οĐến bờ sông.",
+        "οNói chuyện với Cu Lỳ.",
+        "οNgồi chờ.",
+        "οNhận ống tre chứa nước tiểu đồng tử."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 22,
+      "title": "Cựa gà trên sân",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Đến sân đá gà, theo kèo Trần Kê gợi ý, xin trứng tươi.",
+        "accept NPC: (Auto)",
+        "complete NPC: Trần Kê",
+        "dialog accept",
+        "οTrần Kê: “Ô Mắt Lửa! Đâm vô! Đấy, một cựa thôi mà nó lảo đảo rồi! Ha ha, coi kìa, coi kìa!”",
+        "οTrần Kê: “Thấy chưa! Gà nhà ta nuôi từ trong trứng, ăn thóc rang, ăn nghệ, ngủ còn có khăn phủ. Giờ ra sân, nó cắn phát nào là đối thủ bỏng phát đó!”",
+        "οNhân vật chính: “Đúng là gà bác nuôi khác hẳn. Đá hiểm, gan lì, coi mà lạnh sống lưng. Người nuôi cũng giỏi lắm… nhìn như này chắc là tuyển chọn từ còn trong trứng nhỉ?”",
+        "οTrần Kê: “Ờ, trứng mà không chắc thì đừng mong nở gà chiến. Ổ nào ta cũng bới từng quả, nâng như nâng vàng. Người ta chọn gà khi lớn, còn tôi chọn ngay từ trong ổ!”",
+        "οNhân vật chính: “Nghe anh nói… tôi cũng muốn được hưởng chút vía gà hay. Nếu có thể… cho tôi xin một hai quả, coi như mang theo cho gặp may.”",
+        "dialog complete",
+        "οTrần Kê: “Ha ha! Nói năng khéo đấy. Sáng nay ổ gà nhà ta cũng vừa đẻ, ta lựa mấy quả giữ lại rồi, còn đây có mang dư mấy quả chắc tay định ra chợ đổi chút đồ. Mà ngươi xin thì ta cho vài quả lấy may!”",
+        "οTrần Kê: “Cầm lấy! Người ta bảo trứng đầu mùa giữ vía, đi đâu cũng có thần kê phù hộ. Coi như lộc gà của ta ban cho!”",
+        "οNhân vật chính: “Đa tạ anh Kê. Có được lộc này, tôi yên dạ hơn.”",
+        "οTrần Kê: “Ờ, giữ kỹ đấy. Rơi vỡ thì vía cũng tan. Ha! Mai nhớ ghé coi trận khác, ta cho coi con Bạc Mào. Nó còn dữ hơn con này nữa!”",
+        "target",
+        "οTới sân đá gà.",
+        "οNói chuyện với Trần Kê.",
+        "οXem trận.",
+        "οNhận trứng gà."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 23,
+      "title": "Cực dương",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Pha chế theo lời bà Mắm.",
+        "accept NPC: (Auto)",
+        "complete NPC: Bà Mắm",
+        "dialog accept",
+        "οBà Mắm: “Ơ kìa, nhanh thế mà đã mang về rồi sao. Được, trông cậu có vẻ quyết tâm cao đấy!”",
+        "οNhân vật chính: “Con nghĩ, thà tin còn hơn ngờ. Vào rừng tây, con chẳng dám khinh thường.”",
+        "dialog complete",
+        "οBà Mắm: “Được. Cả hai thứ hợp lại… chính là cực dương. Người xưa đi đêm, đi rừng, vẫn lấy làm bùa. Cậu mang trong người thì ma quái cũng phải né.”",
+        "target",
+        "οPha chế hỗn hợp."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 24,
+      "title": "Một cái đầu lơ lửng",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Vào bìa rừng tây, lần dấu tro/giẻ, đối mặt với ma lai.",
+        "accept NPC: (Auto)",
+        "complete NPC: (Auto)",
+        "dialog accept",
+        "dialog complete",
+        "target",
+        "οVào rừng.",
+        "οĐối mặt và đánh bại ma lai."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 25,
+      "title": "Khúc gỗ lim giữa rừng",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Chặt một cây gỗ và lấy gỗ về",
+        "accept NPC: (Auto)",
+        "complete NPC: (Auto)",
+        "dialog accept",
+        "dialog complete",
+        "target",
+        "οChặt một cái cây và lấy gỗ"
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 26,
+      "title": "Căn lều trong rừng sâu",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Phát hiện lều lạ, nghe thấy nhắc “Đại Hãn”, bị phát hiện, giao đấu, địch rút.",
+        "accept NPC: (Auto)",
+        "complete NPC: (Auto)",
+        "dialog accept",
+        "οÁo đen A: “Cái kế của lão già đó hay thật, dùng phép gọi được hồn con ma lai lên ám cả khu này để không ai dám bén mảng tới làm phiền chúng ta.”",
+        "οÁo đen B: “Quả thật là như vậy, cứ ở yên trong đây, biên thêm mớ giấy yết thị này rồi tuồng ra ngoài chợ, sớm thôi lòng thân cũng sẽ lay động.”",
+        "οÁo đen A: “Cứ như thế, Đại Hãn cũng chẳng cần phải ra tay, mà lòng dân chúng cũng sẽ rời nhau cả hết.”",
+        "dialog complete",
+        "target",
+        "οTiếp cận căn lều lạ.",
+        "οGiao đấu với bọn áo đen."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 27,
+      "title": "Cây gỗ tốt",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Trả gỗ cho Mục, nhận gậy lim.",
+        "accept NPC: (Auto)",
+        "complete NPC: Trần Đăng Mục",
+        "dialog accept",
+        "οTrần Đăng Mục: “Giời ơi, thật sự là giỏi quá! Vác được lim rừng về, lại là hàng tốt thế này, trời phú, quả thật là trời phú.”",
+        "οTrần Đăng Mục: “Nghe đi, tiếng chắc như trống hội. Cây gỗ thế này, làm gậy thì đời đời không lo cong gãy.”",
+        "dialog complete",
+        "οTrần Đăng Mục: “Cầm lấy. Mang về cho lão Tri. Có thanh gậy này, lão chắc vui hết phần đời còn lại.”",
+        "target",
+        "οGiao gỗ cho Trần Đăng Mục.",
+        "οNhận gậy."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 28,
+      "title": "Gậy chống làng",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Giao cây gậy mới cho ông Tri",
+        "accept NPC: (Auto)",
+        "complete NPC: Lão Trần Tri",
+        "dialog accept",
+        "dialog complete",
+        "οTrần Tri: “Trong mấy năm nay, có lẽ đây là lần lão cảm thấy vui nhất. Cảm ơn, cảm ơn! Từ giờ lão có thể tiếp tục ngẫn cao đầu sải bước về đình rồi.”",
+        "target",
+        "οGiao gậy cho Trần Tri."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 29,
+      "title": "Đêm họp dưới đèn",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "mô tả: Họp kín tại nhà thuốc Xuân Lang, trình bày thư giả, lều lạ. Lý trưởng phân công.",
+        "accept NPC: Lý trưởng Trần Thế Lục",
+        "complete NPC: Lý trưởng Trần Thế Lục",
+        "dialog accept",
+        "οNhân vật chính: “Các cụ nhớ tin đồn ma lai người ta nói về rừng phía tây chứ? Đúng là có thật, chính tôi đã đánh với nó. Nhưng nó là trò tà thuật của bọn áo đen đã hại tôi lần trước. Đằng sau khu đó có căn lều. Cùng với mấy kẻ lạ miệng luôn nhắc ‘Đại Hãn’, nhắc tung giấy giả. Tôi lộ mặt, chúng lao vào đánh định bịt đầu mối, nhưng chúng đánh không lại bèn dùng thủ thuật mà thoát. Còn sót lại… những giấy này.”",
+        "οThế Sương: “Ha, đúng là trò của ta, mới đó thôi mà bọn chúng đánh không lại ngươi rồi., thử mà…”",
+        "οXuân Lang: “Gượm đã lão Sương, ông nhìn giấy này đi, giấy lạ, mực lạ. Hệt với tờ hôm trước dân ta truyền ngoài chợ, rõ không phải đồ của làng. Rõ là có kẻ muốn cố ý gieo loạn lòng dân.”",
+        "οThế Sương: “Chậc, lòng dân mà lung thay thì, có luyện binh lực bao nhiêu cũng vô ích. Giặc chẳng cần đánh, lòng đã tan. Quả thật là kế hiểm.”",
+        "οTrần Tri: “Năm xưa, ta đã thấy lửa cháy đỏ sông, xác người nổi trắng. Nay lại nghe ‘Đại Hãn’… Thật là lạnh cả xương sống.”",
+        "dialog complete",
+        "οTrần Thế Lục: “Những chuyện thế này là việc của mấy lão già bọn ta, bởi lời bọn ta ít ra có sức nặng, dễ bề mà làm rõ, làm tỉnh lại lòng dân. Thế nhưng ngươi thân trẻ mà lại bị cuốn vào trực tiếp như vậy. Thật khó tránh, khó tránh khỏi mà. Được rồi, vậy thì ngươi phải cùng mấy ông già này xử lý việc này thôi. Hành sự sắp tới sẽ khó khăn, ngươi về chuẩn bị thêm một thời gian. Thời cơ chín mùi ta sẽ cho gọi.”",
+        "target",
+        "οĐến nhà thuốc.",
+        "οHọp cùng các bô lão."
+      ],
+      "extra_fields": {}
+    },
+    {
+      "id": 30,
+      "title": "Những ngày chuẩn bị",
+      "description": null,
+      "accept_npc": null,
+      "complete_npc": null,
+      "dialog_accept": [],
+      "dialog_complete": [],
+      "targets": [],
+      "notes": [
+        "Trải qua nhiều ngày luyện côn với Thế Sương, tập thở thiền, nhận thuốc cầm máu, bánh lá dong và lời dặn dò.",
+        "► Yêu cầu farm, làm nhiệm vụ phụ, ... khi đạt đủ cấp mở chương nhiệm vụ mới thì mới lên đường"
+      ],
+      "extra_fields": {}
+    }
+  ]
+}

--- a/data/raw/tan_thu.txt
+++ b/data/raw/tan_thu.txt
@@ -1,0 +1,562 @@
+Cốt truyện và Nhiệm vụ Tân thủ
+Contents
+Cốt truyện và Nhiệm vụ Tân thủ1
+Sơ lược nội dung3
+Chi tiết5
+1.Rừng tre ban sớm5
+2.Bóng đen trong rừng6
+3.Một sáng Tức Mặc7
+4.Lời thưa nơi đình Tức Mặc8
+5.Võ học làng Tức Mặc9
+6.Bát chè xanh đầu ngõ10
+7.Gáo nước giếng làng11
+8.Búa lửa trong lò12
+9.Lời đồn chợ quê13
+10.Dò chuyện ở chợ 1 – Lời thuế nặng trĩu14
+11.Dò chuyện ở chợ 2 – Tiếng đồn tiếng chợ15
+12.Dò chuyện ở chợ 3 – Mùi mắm mùi đời16
+13.Dò chuyện ở chợ 4 – Mảnh giấy miếng trầu17
+14.Thương nhân mấu chốt19
+15.Ba chiếc phong thư21
+16.Giao thư 1 - Hơi thở an tĩnh22
+17.Giao thư 2 – Thỏ xào và lá thuốc23
+18.Giao thư 3 – Gậy già chờ tay24
+19.Lời đồn rừng tây25
+20.Tìm mẹo trấn âm26
+21.Mồi cá bên sông28
+22.Cựa gà trên sân29
+23.Cực dương30
+24.Một cái đầu lơ lửng31
+25.Khúc gỗ lim giữa rừng31
+26.Căn lều trong rừng sâu31
+27.Cây gỗ tốt32
+28.Gậy chống làng33
+29.Đêm họp dưới đèn33
+30.Những ngày chuẩn bị34
+
+
+Sơ lược nội dung
+Năm 1283, tại làng Tức Mặc. Nhân vật chính (NVC) là một dân làng bình thường, cha là dân binh hy sinh trong trận chiến chống quân Mông - Nguyên lần thứ nhất, mẹ vì đau buồn mà sinh bệnh rồi cũng qua đời, NVC sống lặng lẽ nhờ rừng tre và chiếc rìu cũ. Một buổi tờ mờ sáng cũng như bao ngày, NVC vào rừng tre thì phát hiện có tiếng tranh cãi, NVC nghe lén ba kẻ áo đen tính mưu phá hoại: trách nhau rằng bạc vàng của Đại Hãn bao lâu qua đã hao phí, rồi bàn nhau chỉ cần gây loạn ở Tức Mặc, đó sẽ là mồi lửa đầu tiên để lòng dân lung lay. Bị phát hiện và giao chiến, sức yếu nên NVC ngất đi, may được lính gác đưa về nhà thầy thuốc Trần Xuân Lang.
+Tỉnh lại, NVC đến đình trình báo. Lý trưởng Trần Thế Lục dặn phải giữ kín, đồng thời gửi NVC sang tập võ với Trần Thế Sương. Ở sân tập, cùng sự thử sức của chàng trai Huy Phong, anh lần đầu cầm vũ khí chiến đấu → unlock: chọn vũ khí đầu tiên.
+Trong khi đó, làng bắt đầu xôn xao với tin đồn “triều đình vét thuế”. Sau khi giúp ông rèn Trần Thế Kim → unlock: Rèn. Ông mới nói cho NVC nghe về mấy lời đồn gần đây, NVC quay về báo tin lý trưởng và NVC được giao xuống chợ dò hỏi. Có người tin, có người phủ nhận, và cuối cùng Trần Thị Quýt trao cho NVC một tờ yết thị làm giả con dấu triều đình. Thương nhân Trần Đăng Kiến sau khi xem đã nhận ra đây là giấy lạ, chắc chắn có bàn tay ngoài làng. Tin được báo lại cho Lý trưởng, và ông quyết định họp kín các bô lão.
+Trước buổi họp, NVC được giao mang thư mời đến ba người trụ cột.
+•Trần Thế Sương dạy NVC ngồi thiền, giữ tâm vững trước sóng gió → unlock: Ngồi thiền.
+•Thầy thuốc Xuân Lang hướng dẫn hái thuốc, bẫy thỏ, chế thuốc và nấu ăn; Quỳnh còn nấu cho NVC thịt thỏ xào thảo dược → unlock: Chế thuốc + Nấu ăn.
+•Lão Trần Tri - cựu binh già mất cả ba con trai trong kháng chiến - nhờ anh đi tìm cây gậy lim mới để chống cho thời gian tới vì có thể cơ sự nhiều, cần phải đi lại.
+NVC đến xưởng gỗ Trần Đăng Mục, biết rằng gỗ lim tốt chỉ có trong rừng tây, nơi bị đồn có ma lai. Theo lời bà Mắm, để trấn áp tà khí cần “trứng gà + nước tiểu đồng tử”.
+•Anh gặp cu Lỳ bên sông, câu cá cùng một lúc rồi lấy được nước tiểu → unlock: Câu cá.
+•Sau đó gặp Trần Kê ở sân đá gà, cá cược chọn gà thắng và được thưởng trứng → unlock: Đá gà.
+Pha chế theo lời bà Mắm, anh vào rừng, đối mặt và đánh bại ma lai. Trong lúc tìm cây gỗ tốt, NVC tình cờ phát hiện một ngôi lều lạ. Bên trong có hai kẻ khả nghi, miệng nhắc đến “Đại Hãn”. Trong lúc NVC nghi vấn Ma lai là trò che mắt của chúng để người ta không bén mảng để chỗ cắm trại. Chúng phát hiện ra NVC, một trận chiến kịch liệt nổ ra. Lần này, nhờ võ nghệ đã luyện, anh không còn yếu thế. Chúng rõ ràng cùng hội với ba kẻ áo đen trước đó nhưng lực yếu hơn. Cuối cùng, khi NVC vừa lùi ra, chúng dùng thủ thuật che mắt để tẩu thoát, để lại lều và một mớ những giấy “Yết thị” giả kia. Không kịp truy đuổi, NVC đành mang gỗ lim về.
+Trần Đăng Mục sau đó gia công thành cây gậy chắc chắn cho lão Trần Tri. → unlock: Nghề mộc (chế gỗ)
+Cuộc họp kín diễn ra tại nhà thuốc Xuân Lang. NVC báo cáo lại toàn bộ: từ tờ yết thị giả, đến chuyện gặp hai kẻ nhắc “Đại Hãn”. Các bô lão tin chắc rằng đây là âm mưu từ bên ngoài. Kế hoạch được định: Trần Thế Sương lo huấn luyện trai tráng, Xuân Lang chuẩn bị thuốc men và lương thảo, Trần Tri trấn an bô lão, còn nhân vật chính - ít bị chú ý - sẽ thay mặt làng mang thư mật lên Thăng Long → unlock: Nhiệm vụ chính - Hành trình Thăng Long.
+Sau nhiều ngày rèn luyện và chuẩn bị (level cap để yêu cầu làm thêm nhiệm vụ phụ), sáng hôm khởi hành, Lý trưởng trao cho NVC ba phong thư niêm kín, dặn dò phải giữ vững chí khí. Từ một tiều phu vô danh, NVC nay mang trọng trách lớn lao: lên đường rời Tức Mặc, đem theo gánh nặng yên bình của ngôi làng, và rộng hơn là cả Đại Việt.
+
+Chi tiết
+1.Rừng tre ban sớm
+•[mô tả] Vác rìu đi vào rừng tre lúc rạng sáng. Vô tình nghe ba kẻ lạ bàn mưu. 
+•[accept NPC] (Auto - mở màn)
+•[complete NPC] (Auto - khi bị phát hiện)
+•[dialog accept]
+οGiọng khàn: “Bao nhiêu năm rồi mà cái xứ Đại Việt này vẫn yên bình thế kia… chẳng lẽ bạc vàng của Đại Hãn lại đổ sông đổ biển hết sao?” 
+οGiọng trầm: “Ngươi nóng nảy quá. Bề ngoài yên ổn thôi, chỉ cần một vết rạn nhỏ thì cả triều đình sẽ lung lay. Việc của chúng ta là châm cái vết rạn đó.” 
+οGiọng thứ ba, dứt khoát: “Ngay tại chốn làng quê này cũng đủ. Nếu Tức Mặc loạn, lòng người khắp nơi sẽ bất an. Chúng sẽ thấy triều Trần không còn bất khả xâm phạm nữa.” 
+οNhân vật chính: “Quái lạ… rạng sáng nay sao lại có người trong rừng? Lời lẽ nghe toàn chuyện phản nghịch… Ta… ta phải nhìn cho rõ.” 
+•[dialog complete]
+οÁo đen A: “Ai!? Ai đang nấp trong bụi kia? Mau ra!” 
+οÁo đen B: “Có kẻ nghe lén! Bắt nó!”  
+•[target]
+οĐi theo đường mòn vào rừng. 
+
+2.Bóng đen trong rừng
+•[mô tả] Bị phát hiện, chống trả đám áo đen giữa rừng tre. Rồi lúc lính canh đến thì ngất vì kiệt sức.
+•[accept NPC] (Auto - tiếp nối Quest 1)
+•[complete NPC] (Auto - khi địch rút chạy)
+•[dialog accept]
+οÁo đen C: “Một thằng tiều phu nhãi ranh mà cũng dám mở miệng hỏi tội? Ngươi đã nghe hết rồi thì sống làm gì nữa.” 
+οÁo đen A: “Nhanh! Giết nó, chặt đầu vứt xuống suối, đừng để lại dấu vết.”  
+•[dialog complete] 
+οLính gác: “Ai đó trong rừng? Đứng lại! Lính tuần đây! Mau ra!” 
+οÁo đen A: “Khốn kiếp, lính đến rồi!” 
+οÁo đen B: “Không kịp giết nó nữa, rút mau!” 
+οÁo đen C: “Nhưng nếu nó sống...” 
+οÁo đen A: “Im! Giữ mạng đã, đi!” 
+•[target]
+οGiao đấu với nhóm áo đen. 
+
+3.Một sáng Tức Mặc
+•[mô tả] Tỉnh lại tại nhà thầy thuốc Trần Xuân Lang. 
+•[accept NPC] (Auto)
+•[complete NPC] Trần Xuân Lang
+•[dialog accept]
+οTrần Xuân Quỳnh: “Huynh tỉnh rồi! Trời ơi, ta cứ tưởng… đêm qua ta run hết cả người, ngỡ rằng huynh không qua nổi. May mà mấy chú lính gác tuần tra nghe thấy tiếng ẩu đả, họ chạy đến, thấy huynh nằm lăn ngay dưới chân đám áo đen. Họ vừa kịp cõng huynh về đây thôi.” 
+οNhân vật chính: “Thật may quá, cứ ngỡ phải toi rồi”
+οTrần Xuân Quỳnh: “Huynh liều quá. Đêm hôm, rạng sáng một mình vác rìu vào rừng… Lần này còn có người đưa về, chứ nếu trễ thêm một khắc thì…” 
+οTrần Xuân Lang: “Được rồi, Quỳnh, để ta xem cho rõ.”
+οTrần Xuân Lang: “Ừm… chỉ là kiệt sức, mạch cũng tốt hơn rồi. Đánh đến thế này. bọn kia không phải cướp vặt đâu.” 
+οNhân vật chính: “Tôi nghe chúng nói… muốn gieo loạn ngay tại Tức Mặc… Nếu là thật thì- ” 
+οTrần Xuân Lang: “Không. Lời ấy chưa được thốt ra ngoài. Ngươi nhớ kỹ: dân làng mà nghe loáng thoáng, lo sợ nổi lên thì bọn kia sẽ đạt mưu. Ngươi còn yếu, lo dưỡng sức. Khi nào gượng dậy được, hãy tự đến đình mà trình bày với Lý trưởng. Đó mới là lẽ phải.” 
+οNhân vật chính: “Tôi… tôi hiểu. Nhưng hình ảnh chúng nói cứ vang trong đầu, chẳng xua đi nổi…” 
+οTrần Xuân Quỳnh: “Uống chút nước đi. Huynh nằm yên, đừng nghĩ ngợi. Để chuyện lớn cho cha và các bô lão lo. Huynh chỉ cần giữ mạng cho chắc.” 
+οNhân vật chính: “Cảm ơn… Quỳnh… Cảm ơn thầy Lang… Lần này, nếu không có mọi người… tôi đã nằm lại trong rừng tre rồi.” 
+οTrần Xuân Lang: “Thân còn thì việc còn. Hãy nhớ: giữ kín miệng, giữ vững thân. Chuyện ở rừng, rồi sẽ có ngày đưa ra ánh sáng, nhưng không phải bằng miệng dân đồn đãi. Nghỉ đi.” 
+•[target]
+οNói chuyện với Trần Xuân Quỳnh và Trần Xuân Lang
+4.Lời thưa nơi đình Tức Mặc
+•[Mô tả] Tới đình, yết kiến Lý trưởng Trần Thế Lục. Thuật lại chuyện rừng tre.
+•[accept NPC] Trần Thế Lục
+•[complete NPC] Trần Thế Lục
+•[dialog accept]
+οTrần Thế Lục: “Ngươi đó à? Ta nghe lính gác báo lại có kẻ lạ trong rừng, nhưng miệng người chưa đủ. Ta muốn nghe chính từ kẻ trong cuộc. Nào, nói đi: rốt cuộc đã xảy ra chuyện gì?” 
+οNhân vật chính: “Bẩm Lý trưởng… rạng sáng hôm kia, tôi vác rìu vào rừng như thường lệ. Bất chợt nghe có ba người lạ nói chuyện. Họ nhắc đến chuyện làm Tức Mặc rối loạn, còn bảo rằng nếu làng này loạn thì cả thiên hạ cũng loạn theo… Tôi men lại gần nghe rõ thì bị chúng phát hiện. Chúng định giết ta để bịt miệng. Tôi chống trả… nhưng sức chẳng thấm vào đâu. May sao lúc đó lính gác tuần tới, chúng sợ bị lộ nên bỏ chạy. Tôi… ngất đi từ lúc ấy.” 
+οTrần Thế Lục: “Hừm… nói năng loạn nghịch, dám mưu tính ngay trong rừng làng này. Quả là chuyện chẳng lành.” 
+οNhân vật chính: “Lý trưởng… liệu có nên báo rộng ra cho dân biết, để họ cảnh giác?” 
+οTrần Thế Lục: “Không được. Địch muốn gieo loạn, ta lại loan tin, khác nào làm thay việc cho chúng. Dân quê nghe chuyện, trong lòng bất an, chỉ càng rối. Phải giữ yên thì mới trị yên.” 
+οNhân vật chính: “Vậy… chúng ta phải làm sao?” 
+οTrần Thế Lục: “Thân ngươi còn non, lại vừa thoát chết. Từ nay, hãy theo Trần Thế Sương ở sân tập mà học võ. Rèn thân mới giữ nổi mạng, có sức mới giữ nổi làng. Không chắc lần sau lính tuần sẽ đến kịp lúc.” 
+οNhân vật chính: “Vâng… tôi đã hiểu.” 
+οTrần Thế Lục: “Việc này, ta sẽ cho người âm thầm dò xét. Còn ngươi, trước hết hãy tự đứng vững đã. Tập trung theo thầy Sương mà luyện tập, có ngày chúng ta sẽ cần đến ngươi.”  
+•[target]
+οTìm gặp và nói chuyện với Lý trưởng Trần Thế Lục
+5.Võ học làng Tức Mặc
+•[mô tả] Gặp Trần Thế Sương ở sân tập, nhận côn tre, tỉ thí với Huy Phong.
+•[accept NPC] Trần Thế Lục (từ quest trước giao chỉ thị)
+•[complete NPC] Trần Thế Sương
+•[dialog accept]
+οTrần Thế Sương: “À, hóa ra ngươi là cái thằng mà Lý trưởng gửi tới đây đấy à? Nhìn bộ dạng ngươi,  tay chân thì lỏng như bún… Nhưng thôi, đến sân này rồi thì không kể là ai, cứ phải tập.” ► Lựa chọn vũ khí khởi đầu  
+οTrần Thế Sương: “Cầm lấy cho chắc.” 
+οHuy Phong: “Ối giời ôi, nom kìa, mới cầm cái [Côn] mà đã lóng nga lóng ngóng như gà mắc tóc. Này ông thầy, để con thử cho hắn một chút đi. Không có ngã thì chẳng bao giờ biết cách đứng lên đâu.” 
+οTrần Thế Sương: “Được, nhưng nhớ tay chân có chừng mực. Ta muốn nó tỉnh, chứ không muốn vác xác về nhà thuốc.”
+οHuy Phong: “Yên tâm, con chẳng đánh chết ai bao giờ. Nào, lại đây! Cầm chắc đi, đừng có buông rơi giữa sân, xấu mặt lắm đấy!”
+•[dialog complete]
+οHuy Phong: “Được đấy! Ta cứ tưởng ngươi chỉ biết vác rìu chặt củi. Ai ngờ cũng lì ra trò.” 
+οTrần Thế Sương: “Chân còn chao đảo, tay còn nặng, nhưng mắt đã biết nhìn. Từ nay ngươi cứ chăm luyện tập. Ngọc thô phải dũa mới thành đá quý. Ngươi còn phải rèn nhiều.”  
+•[target]
+ο1) Tới sân tập. 2) Chọn vũ khí khởi đầu. 3) Combat với Huy Phong.
+6.Bát chè xanh đầu ngõ
+•[Mô tả] Cùng Huy Phong ra quán chè đầu làng, nghe bà Đanh kể chuyện “người lạ từ rừng tre”. 
+•[accept NPC] Huy Phong
+•[complete NPC] Bà Đanh
+•[dialog accept]
+οHuy Phong: “Trông ngươi thở như trâu kéo cày rồi. Nghỉ chút đi. Đầu làng có hàng nước bà Đanh, chè xanh đặc lắm. Uống vào cho tỉnh táo, kẻo nằm vật ra đây thì mất vui.”
+οNhân vật chính: “Ừ, đi thôi.” 
+•[dialog complete]
+οBà Đanh: “Ối giời ôi, tập võ xong mà thở hồng hộc như vừa cày xong mấy sào ruộng thế kia. Nào, ngồi xuống đây, ta rót cho bát chè xanh. Chè mới hái sáng sớm, đắng đầu lưỡi mà ngọt hậu, uống xong tỉnh người ngay.”
+οHuy Phong: “Khát khô cả cổ rồi, bà cứ rót cho đầy bát.  Tên này hôm nay mới tập cũng ra hồn, nhưng sức yếu, thở như bò kéo cày. Cho nó uống bát đặc vào kẻo ngã lăn ra.”
+οNhân vật chính: “Cảm ơn bà. Chè thơm quá, mùi còn hăng hắc mà dễ chịu. Uống vào mát cả ruột gan.”
+οBà Đanh: “Ấy, nói chứ mấy hôm nay ta cũng lắm điều ngờ lắm. Rạng sáng hôm kia, lúc dọn hàng sớm, ta thấy loáng thoáng vài bóng người lạ chạy vội ngang ngõ. Dáng vẻ hớt hải, nom như bị ai dí sau lưng. Từ hướng rừng tre mà ra đấy… Ta thì già mắt kèm nhèm, đâu có chắc, chỉ thấy lạ lắm thôi.”
+οHuy Phong: “Bà thì suốt ngày thấy cái gì cũng thành chuyện. Người lạ đi ngang, ai cấm? Mà rừng tre thì người ta vẫn ra vào lấy củi, có gì đâu.”
+οBà Đanh: “Ờ thì đúng là ai cũng có thể đi. Nhưng thử hỏi, rạng sáng tinh mơ, trời còn tối om, dân làng nào lại tha thẩn chạy như ma đuổi thế? Ta ngồi đây bao năm, khách buôn, người làng đi lại ta đều quen mặt cả. Mấy bóng đó, ta lạ. Thế thôi. Ta kể thế thôi chứ ta cũng chẳng dám đoán gì thêm.”
+οNhân vật chính: “Ừ… cũng phải. Người lạ xuất hiện giờ ấy, quả là khó hiểu thật.”
+•[target 1]
+1.Ra quán nước. 2) Nói chuyện với bà Đanh.
+
+7.Gáo nước giếng làng
+•[mô tả] Ra giếng dội nước, định thần sau buổi tập và câu chuyện ở quán nước.
+•[accept NPC] (Auto - sau quán nước)
+•[complete NPC] (Auto - khi dội nước xong)
+•[dialog accept]
+οHuy Phong: “Thôi nào, uống thế là đủ rồi. Nằm lì ở quán bà Đanh thì có ngày thành lão già nghe chuyện thiên hạ mất. Đi, ra giếng dội gáo nước cho tỉnh táo.”
+οNhân vật chính: “Ừ…  người vẫn còn khó chịu, chắc phải dội cả gáo may ra mới nguôi.”
+οBà Đanh: “Ờ, đi thì đi. Giếng làng nước trong, dội lên mát ruột. Nhưng nhớ đấy, chớ có soi xuống lâu quá, người ta bảo soi giếng lúc sẩm tối dễ thấy ma chứ chẳng thấy mặt mình đâu.”
+οHuy Phong: “Lại bày chuyện hù dọa rồi. Thôi, bà cứ ngồi đếm khách đi, bọn tôi ra giếng cho mát.” 
+•[dialog complete]
+οNhân vật chính: “Ơ… nghe gì không? Tiếng búa rèn. Mà sao hôm nay dồn dập thế?”
+οHuy Phong: “Phải lò của bác Kim rồi. Ông ấy tính nóng như lửa, búa nện thế kia thì chắc đang bực chuyện gì. Hay qua xem thử?”.
+οNhân vật chính: “Ừ, tiện đường thì ghé. Ít ra cũng học được thêm cái gì.”
+•[target] 
+1) Ra giếng. 2) Dội nước lên mặt.
+
+8.Búa lửa trong lò
+•[mô tả] Ghé lò rèn, giúp ông Kim. Nghe ông bực bội về lời đồn “vét thuế”. Mở khóa sử dụng tính năng [Lò rèn]
+•[accept NPC] (Auto - sau Giếng làng)
+•[complete NPC] Trần Thế Kim
+•[dialog accept]
+οTrần Thế Kim: “Đứng đấy làm gì? Muốn ngó thì ngó xa xa thôi, lại gần coi chừng lửa táp vào mặt đấy! Còn nếu tiện tay thì giúp ta chút.” 
+οHuy Phong: “Khéo vụng thì rụng cả tay. Cẩn thận đấy, không thì thầy thuốc Xuân Lang lại có việc băng bó cho ngươi.”
+•[dialog complete]
+οTrần Thế Kim: “Hầy… rèn đồ đã mệt, lại còn phải nghe thiên hạ lắm mồm. Cái chợ mấy bữa nay chỉ rặt một chuyện: triều đình sắp vét thêm thuế, thu nặng gấp đôi. Tai ta ù hết cả lên!”
+οNhân vật chính: “Thuế… thật ạ? Sao tôi chưa nghe tin gì từ đình?”
+οTrần Thế Kim: “Tin tức thì phải từ trên xuống! Nếu có lệnh, Lý trưởng phải là người báo đầu tiên. Thế mà chưa ai nói gì, ngoài chợ đã loạn cả lên. Toàn cái lũ ưa đồn thổi, chưa thấy giấy trắng mực đen đã hò hét loạn cả.”
+οHuy Phong: “Nhưng dân chợ thì cũng khổ. Nghe loáng thoáng chuyện vét thuế thì ai mà chẳng sợ. Bán con cá, mớ rau còn run.”
+οTrần Thế Kim: “Ừ, khổ thì khổ. Nhưng thử nghĩ xem, nếu thật, ta còn ngồi đây được chắc? Triều đình mà vét, lò rèn này cũng sập. Ta cũng chẳng tin. Chỉ tức là: ngày nào cũng nghe, nghe mãi cũng bực. Búa nặng thêm vì chuyện chợ búa, chứ không phải vì sắt.”
+οNhân vật chính: “Vậy… có khi nên thưa lại với Lý trưởng, để ông ấy phân rõ thực hư. Chứ để dân cứ rì rầm, e là bất ổn.”
+οTrần Thế Kim: “Ừ, phải. Ngươi thử đem việc ấy đến đình thưa với ông Lục xem sao. Ta ở đây búa nện, cãi nhau với chợ thì vô ích. Việc này, cần người tai nghe mắt thấy đi nói thì mới nên chuyện.”
+οNhân vật chính: “Được rồi, tôi sẽ đi ngay. Tôi cũng muốn biết rõ thực hư, chứ nghe xong trong lòng cũng rối bời.”
+οHuy Phong: “Thế thì tốt. Nghe lời bác Kim cũng phải. Việc lớn phải đưa ra đình, chứ ngồi mà bàn thì chỉ thêm rối.”
+οTrần Thế Kim: “Ừ, đi đi. Còn ta lo cái lò này. Tin đồn có thật hay không, rồi cũng sẽ lòi mặt chuột thôi.” 
+•[target]
+1.Đến lò rèn.
+2.Giúp ông Kim. ► Mở khóa tính năng [Lò rèn]
+3.Nghe ông nói về lời đồn.
+
+9.Lời đồn chợ quê
+•[mô tả] Quay lại đình, báo cho Lý trưởng chuyện lời đồn “vét thuế” mà Trần Thế Kim kể. Nhận chỉ thị phải ra chợ dò hỏi, nghe đủ hai phía.
+•[accept NPC] (Auto - sau khi rời lò rèn)
+•[complete NPC] Lý trưởng Trần Thế Lục
+•[dialog accept]
+οTrần Thế Lục: “Ngươi quay lại sớm thế. Có chuyện gì mà vào đây?”
+οNhân vật chính: “Bẩm Lý trưởng, tôi vừa qua lò rèn của bác Kim. Ông ấy tức lắm, bảo chợ mấy bữa nay toàn rộ lên lời đồn triều đình sẽ vét thêm thuế nặng. Nghe nhiều, ai cũng hoang mang. Ông Kim thì không tin, nhưng tai cứ phải nghe, đâm ra bực.”
+οTrần Thế Lục: “Hừ… thuế má là việc trọng. Có tăng giảm thì cũng phải từ triều đình, qua phủ, rồi mới xuống tới làng. Sao dân ngoài chợ lại biết trước ta? Rõ ràng có kẻ gieo lời xấu để xao lòng người.”
+οNhân vật chính: “Tôi cũng nghĩ vậy, có khi lại liên quan đến chuyện hôm trước. Nhưng nếu cứ để lời đồn lan, e là trong làng bất an.”
+οTrần Thế Lục: “Đem lính đi rầm rộ tra xét lúc này chưa chắc đã hay. Địch muốn dân loạn, ta lại làm dân xôn xao thì khác nào mắc mưu. Phải nhẹ tay mà khéo.”
+•[dialog complete]
+οTrần Thế Lục: “Ngươi vừa trải qua chuyện ở rừng, nay lại tận tai nghe ở lò rèn. Ngươi là kẻ ít ai để ý, dễ len lỏi. Vậy ngươi thử ra chợ, khéo léo mà hỏi. Đừng để lộ ý dò xét. Hỏi cho đủ hai phía: kẻ tin, kẻ không tin. Rồi về đây báo lại cho ta.”
+οNhân vật chính: “Chà, đây thực sự là một trách nhiệm lớn với tôi.”
+οTrần Thế Lục: “Ngươi chỉ cần lắng nghe. Người thật sự bực tức thì tự khắc sẽ tuôn ra. Người không tin thì sẽ có cách gạt đi. Việc của ngươi là ghi nhớ, chứ không phải tranh cãi. Cứ bình thản, như thể trò chuyện ngoài chợ thôi.”
+οNhân vật chính: “Được thôi, tôi biết mình cần phải làm gì rồi.”
+οTrần Thế Lục: “Lời đồn như lửa âm trong rơm, gió nhẹ cũng bùng. Phải nắm cho rõ, rồi dập ngay, kẻo muộn thì cháy lan khắp làng. Ngươi đi đi. 
+•[target]
+1.Quay lại đình và nói chuyện với Lý trưởng. 
+
+10.Dò chuyện ở chợ 1 – Lời thuế nặng trĩu
+•[mô tả] Ra chợ Tức Mặc, dò hỏi chuyện từ người dân.
+•[accept NPC] (Auto - sau chỉ thị của Lý trưởng)
+•[complete NPC] Trần Văn Cẩn
+•[dialog complete]
+οNhân vật chính: “Chào bác Cẩn, cá sáng nay nhiều thế. Cá rô này còn quẫy khỏe lắm, chắc mới kéo từ đầm về?”
+οTrần Văn Cẩn: “Ừ, đêm qua đi thả lưới, giờ mang ra bán. Cá làng mình nuôi chứ đâu, thịt chắc vô cùng.”
+οNhân vật chính: “Đúng thật, vảy sáng lấp lóa. Bác cho tôi dăm con nhỏ về kho ăn cơm. À… mà dạo này chợ đông vui ghê, ai cũng nói cười, xôn xao đủ chuyện.”
+οTrần Văn Cẩn: “Xôn xao gì đâu, toàn cái chuyện làm dân rầu mặt. Ngươi chưa nghe à? Họ bảo triều đình vét thuế nữa kìa.”
+οNhân vật chính: “Vét thuế ạ? Tôi chỉ nghe loáng thoáng, chưa rõ thế nào. Người thì bảo có, người thì gạt đi.”
+οTrần Văn Cẩn: “Có chứ! Cả chợ nói ầm ầm cả tuần nay. Nếu thật thì phen này dân đen chỉ còn nước bán nhà, bán trâu. Ta buôn cá mà còn thấy lo, huống chi nông dân gánh sưu nặng nề.”
+οNhân vật chính: “Nghe bác nói cũng thấy sợ thật. Nhưng… bác có chắc không? Hay chỉ là tin gió thôi?”
+οTrần Văn Cẩn: “Chắc với không chắc! Ở cái xứ này, trên bảo thì dưới nghe. Lý trưởng thì cũng chỉ biết truyền lại thôi. Hầy, ngươi còn trẻ, chưa gánh sưu nên chưa thấy cái cảnh người ta bán thóc trả thuế đâu.”
+οNhân vật chính: “Tôi hiểu rồi. Nghe bác kể mà tôi cũng rùng mình.” 
+•[target]
+1.Nói chuyện với Trần Văn Cẩn
+
+11.Dò chuyện ở chợ 2 – Tiếng đồn tiếng chợ
+•[mô tả] Ra chợ Tức Mặc, dò hỏi chuyện từ người dân
+•[accept NPC] (Auto)
+•[complete NPC] Mụ Còng
+•[dialog complete]
+οNhân vật chính: “Chào mụ Còng, rau muống mớ này xanh mướt thế. Lá còn đẫy nhựa, chắc mới cắt sáng nay hả mụ?”
+οMụ Còng: “Ừ, sáng sớm ra ruộng cắt đấy. Nước mưa đêm qua ngấm vào, rau xanh hơn thường ngày. Làng này chỉ cần ruộng còn nước, rau còn mọc, là ta còn bán được.”
+οNhân vật chính: “Đúng là rau vườn mình khác hẳn. Mụ bán bao năm rồi, chắc chợ này chuyện gì cũng qua tai, mắt.”
+οMụ Còng: “Thì tai già này ngày nào chả nghe. Người ta nói lắm, nhưng không phải cái gì cũng đáng tin. Cứ vài bữa lại có chuyện đồn nhảm, làm dân hoang mang.”
+οNhân vật chính: “Vâng, tôi cũng nghe loáng thoáng mấy lời về sưu thuế. Nhưng chẳng biết thực hư ra sao.”
+οMụ Còng: “À cái chuyện thuế má ấy hả? Nhảm nhí! Triều đình vừa mới tha sưu năm ngoái, người dân mới được thở một hơi. Nay ai đời lại quay ra vét tiếp? Toàn miệng lưỡi kẻ xấu, muốn làm làng này rối loạn.”
+οNhân vật chính: “Nhưng mà… người ngoài chợ nhiều kẻ nói có lý …”
+οMụ Còng: “Lý hay không lý thì triều đình lo. Dân như ta chỉ lo cấy cày, đóng góp đúng lệnh, đúng bổn phận. Bao năm nay, nghe tin đồn thì nhiều, mấy lần thành thật? Đồn càng to, càng vô lý. Chỉ tội cho những đứa nhẹ dạ tin theo, rồi hoang mang, bỏ cả việc ruộng đồng.”
+οNhân vật chính: “Mụ nói cũng phải… không chắc mà loan ra thì hỏng chuyện.”
+οMụ Còng: “Ừ, nhớ lấy. Tai nghe thì cứ để tai, đừng để miệng nói ra. Dân quê có cái gì ngoài ruộng với rau đâu. Để tâm nhiều chỉ thêm bệnh.” 
+•[target]
+οNói chuyện với mụ Còng
+
+12.Dò chuyện ở chợ 3 – Mùi mắm mùi đời
+•[mô tả] Ra chợ Tức Mặc, dò hỏi chuyện từ người dân
+•[accept NPC] (Auto)
+•[complete NPC] Mụ Mướp
+•[dialog complete]
+οNhân vật chính: “Chào mụ Mướp, mắm hôm nay nặng mùi quá, chắc để ủ kỹ lắm đây. Cho tôi xin ít về kho cá.”
+οMụ Mướp: “Ha, mắm mà không nặng thì đâu còn là mắm! Người ta ăn mắm là ăn cái mùi, cái vị nó thấm vào cơm. Cứ lấy một tí thôi thì gọi là hết nồi cơm đấy.”
+οNhân vật chính: “Nghe mụ nói mà tôi cũng thèm. Mà dạo này chợ đông, người nào người nấy cũng bàn tán chuyện… chẳng mấy khi yên.”
+οMụ Mướp: “Lại cái vụ thuế chứ gì. Cả chợ ai mà chẳng nghe. Người thì bảo triều đình vét thêm cho đủ chi tiêu. Hầy, ta nghe mà lo hết ruột gan. Lão chồng ta còn tính: phen này chắc phải bán nốt con trâu già mới đủ nộp.”
+οNhân vật chính: “Đến mức ấy thật sao? Biết đâu chỉ là tin thổi phồng?”
+οMụ Mướp: “Tin thì tin, mà không tin thì cũng phải lo. Bọn trên đầu nói một câu, dưới này gồng cả đời. Ngươi còn trẻ, chưa nếm cảnh gom từng đấu gạo để nộp, mới thấy nó xa. Chứ thử như ta, một năm đóng sưu xong, thóc chẳng còn bao nhiêu. Năm nào cũng chật vật, giờ mà vét thêm nữa thì… hầy, chắc ta chỉ còn cái xác.”
+οNhân vật chính: “Mụ nói vậy, tôi cũng thấy sợ.”
+οMụ Mướp: “Sợ thì phải! Đừng tưởng người chợ chỉ biết buôn bán. Chuyện không phải tự dưng. Có khói thì mới có lửa. Có người đưa cho ta xem rồi, giấy trắng mực đen của triều đình rõ ràng.” 
+•[target]
+οNói chuyện với mụ Mướp
+
+13.Dò chuyện ở chợ 4 – Mảnh giấy miếng trầu
+•[mô tả] Ra chợ Tức Mặc, dò hỏi chuyện từ người dân
+•[accept NPC] Trần Thị Quýt
+•[complete NPC] Trần Thị Quýt
+•[dialog accept]
+οNhân vật chính: “Chào chị Quýt, cau têm đều quá. Cho tôi ít lá trầu với mấy quả cau… để thắp hương cha mẹ ở nhà.”
+οTrần Thị Quýt: “Ờ… cũng quý cho ông bà nhà cậu. Người ta bây giờ mải lo miếng ăn, mấy ai còn nhớ hương khói. Cậu còn trẻ mà giữ được nếp xưa, hiếm lắm. Trầu cau này mà đặt lên mâm hương, nhìn cũng ấm lòng người khuất.”
+οNhân vật chính: “Ở một mình, nhiều lúc chỉ mong có làn khói hương cho đỡ lạnh lẽo. Cơm nước thì sao cũng được, nhưng thiếu hương khói thì thấy trống trải.”
+οTrần Thị Quýt: “Ừ… có khói hương là còn chỗ dựa. Bằng không, nhà cửa cũng lạnh tanh. Ta buôn ở chợ bao năm, thấy nhiều cảnh… người bỏ quên bàn thờ, con cái chẳng đoái hoài, nghĩ mà thương.” 
+οTrần Thị Quýt: “Mà gần đây, cậu có nghe người ta nói gì không? Ở chợ này, người ta nói nhiều lắm, lời ngay lời sai lẫn lộn, dễ bị cuốn lắm đó.”
+οNhân vật chính: “Vâng… tôi cũng nghe nhiều người bàn về thuế má. Người thì quả quyết triều đình vét, người lại gạt đi. Tôi chẳng biết đâu mà lần.”
+οTrần Thị Quýt: “Ở chợ này, tai ta ngày nào cũng ù lên vì nghe thiên hạ cãi cọ. Người thì thề sống chết là triều đình vét thuế, kẻ thì cười khẩy bảo bịa đặt. Nghe riết, lòng ta cũng loạn cả.”
+οNhân vật chính: “Tôi thì nghĩ… nếu thật, ắt đình đã báo. Chợ búa nhiều miệng, gió thổi kiểu gì cũng hóa thành bão. Tin theo rồi nói lại, chỉ thêm rối.”
+οTrần Thị Quýt: “Ờ hầy… nghe người ta nói vậy mà cậu cũng chẳng động lòng gì à? Người thì sợ xanh mặt, còn cậu… cứ thản nhiên.”
+οNhân vật chính: “Không phải thản nhiên, mà là sợ mình tin sai. Đợi đình có giấy có lời, khi ấy mới lo cũng chưa muộn.” 
+οTrần Thị Quýt: “Nói thật với cậu… sáng sớm nay có gã lạ ghé mua cau. Khi dọn hàng ta thấy rơi cái tờ giấy này. Ta chẳng biết chữ, nhưng từng thấy giấy quan dán ở đình. Giấy này có dấu đỏ như quan, nhưng nó lại thì mỏng sần, dúm dó, lại in cái dấu đỏ nhòe nhoẹt. Nhìn đã thấy lạ.”
+•[dialog complete]
+οNhân vật chính: “Đúng là chẳng giống giấy yết thị. Thiếu ngày tháng, chẳng ghi nơi niêm yết, dấu đỏ lại mờ. Lạ thật.”
+οTrần Thị Quýt: “Đấy. Ta cũng thấy gai người. Định đốt đi mà sợ… lỡ là thật thì thành mang tội. Giữ lại thì lo, đàn bà buôn chợ ôm giấy quan trong người… lỡ bị tra hỏi, ai tin ta trong sạch?” 
+οTrần Thị Quýt: “Cậu cầm lấy. Nhưng nhớ, đừng nói là ta đưa. Ta chẳng dám lên đình, sợ mang tiếng tung tin. Nếu cậu muốn cho rõ, thì… thử mang qua ông Kiến hỏi. Ông ấy buôn rộng, nghe nhiều, biết đường. Rồi sau đó… cậu nộp thẳng cho Lý trưởng. Miệng cậu kín, ta mới dám gửi.”
+οNhân vật chính: “Tôi hiểu rồi. Chị để tôi lo liệu.” 
+•[target]
+Nói chuyện với Trần Thị Quýt
+
+14.Thương nhân mấu chốt
+•[mô tả] Mang thư nặc danh tới nhà/sạp Trần Đăng Kiến. Ông bác bỏ lời đồn, rồi soi kỹ thư, kết luận giấy và mực lạ, chắc có bàn tay ngoài. Khuyên phải báo ngay Lý trưởng.
+•[accept NPC] (Auto - sau khi nhận thư từ Trần Thị Quýt)
+•[complete NPC] Trần Đăng Kiến
+•[dialog accept]
+οNhân vật chính: “Chào bác Kiến. Sạp đông khách quá, đúng là người ta bảo, đi một vòng chợ chi bằng ghé chỗ bác Kiến.”
+οTrần Đăng Kiến: “Ờ thì, ta buôn cho đủ thôi. Muối gạo, nồi niêu, vải vóc… có gì đổi được thì ta bán. Để bà con khỏi chạy lên tận chợ phủ, mệt người.”
+οNhân vật chính: “Chợ đông thật, nhưng nghe riết chỉ toàn chuyện thuế má. Người thì sợ, người thì gạt. Bác đi nhiều, hẳn nghe nhiều hơn tôi.”
+οTrần Đăng Kiến: “Hầy, lời chợ thì gió. Nếu có thật, đã phải từ phủ xuống đình, trống mõ gọi dân, bô lão đọc giữa sân. Ta đi bến sông, chợ phủ, chưa thấy ai nhắc. Mà mấy bận như này, toàn tin vớ vẩn, hù cho dân rối trí.”
+οNhân vật chính: “Tôi cũng mong thế… nhưng bác xem thử cái này đã.”
+οTrần Đăng Kiến: “Cái gì? Đừng giơ cao, kẻo lắm con mắt dòm.”
+οNhân vật chính: “Trong này có kẹp một mảnh giấy. Tôi nhặt được, chưa dám đưa ai xem.”
+•[dialog complete]
+οTrần Đăng Kiến: “…Ờ hầy. Giấy này… coi thì ra dáng giấy quan, mà sờ vào thì khác. Nhàu dúm, mỏng lét. Dấu đỏ in lệch, nhòe nhoẹt. Câu chữ thì nửa mùa, lối văn chắp vá. Nói chiếu theo mà không ghi ngày, cũng chẳng chỗ niêm yết. Yết thị thật không ai làm vậy.”
+οNhân vật chính: “Thế… là giả bác nhỉ?”
+οTrần Đăng Kiến: “Ừ. Ta vừa ở bến về, lái đò bảo làng bên sáng nay cũng nhặt được một tờ giống hệt. Bên Thượng Lỗi cũng rộ lên. Một sớm mà rải khắp, rõ ràng là kẻ ngoài tung ra. Dân mình nghèo chữ, nghèo giấy, ai bày nổi trò dấu má như thế này?”
+οNhân vật chính: “Vậy… tôi nên làm gì?”
+οTrần Đăng Kiến: “Cất kỹ đi, rồi đợi xế bóng, đi ngõ sau mà vào đình, nộp thẳng cho ông Lục. Gặp ai hỏi, nói trầu cau biếu lão Lục, đừng nhắc nửa lời về tờ giấy. Nhớ lấy, lỡ ra là hỏng.”
+οNhân vật chính: “Tôi hiểu rồi. Đa tạ bác.”
+οTrần Đăng Kiến: “Ừ. Nhớ cho rõ: lệnh thật thì trống mõ gọi dân ra sân đình, giấy dán ngay cột đình, không bao giờ xuất hiện ở quán chợ. Đấy mới là dấu chắc. Còn mấy thứ này… chỉ là gió độc gieo hoang mang thôi.”
+•[target]
+1.Mang thư đến nhà/sạp Trần Đăng Kiến.
+2.Nói chuyện và nghe ông phân tích lời đồn.  
+
+15. Ba chiếc phong thư
+•[mô tả] Trình lại thư nặc danh và kết luận của Trần Đăng Kiến cho Lý trưởng. Nhận từ ông ba phong thư mời họp kín, gửi cho Thế Sương, Xuân Lang, và lão Trần Tri.
+•[accept NPC] (Auto - sau khi rời nhà/sạp Trần Đăng Kiến)
+•[complete NPC] Lý trưởng Trần Thế Lục
+•[dialog accept]
+οNhân vật chính : “Bẩm ông Lục… tôi có chuyện gấp, xin vô trình.”
+οTrần Thế Lục: “Ờ, là cậu hả? Trưa nắng chang chang mà mò tới đình, hẳn chẳng phải chuyện chơi. Vào đi.” 
+οNhân vật chính: “Tôi… nhặt được thứ này ngoài chợ. Ban đầu con sợ, chẳng dám mở. Sau đem qua bác Kiến coi, ông ấy bảo giả. Con mới dám đem tới đây.”
+οTrần Thế Lục: “Cậu biết… ôm cái này vô đình là gánh thế nào không? Một khi ta nhận, là coi như cậu dính việc lớn rồi đấy.”
+οNhân vật chính: “…Tôi biết nặng. Nhưng giấu thì nó đi thì còn nặng hơn, nên tôi liều mang tới.” 
+οTrần Thế Lục: “Hầy… coi nè. Giấy mỏng thế này, dúm dó như lá chuối khô. Dấu đỏ đóng lệch, nhòe cả mực. Chữ thì ghi ‘yết thị’ mà chẳng có ngày, chẳng lạc khoản. Giấy quan thật phải qua tay ta, rồi dán ngay cột đình. Đâu có chuyện rơi rớt ở ngoài kia.” 
+οTrần Thế Lục: “Có ai thấy cậu lượm không? Nói cho thật.”
+οNhân vật chính: “Thưa… không. Người ta xúm bàn, chuyền tay. Tôi thừa lúc họ xao nhãng mà nhặt, giấu ngay trong gói trầu.”
+•[dialog finish]
+οTrần Thế Lục:“…Chuyện lần trước của ngươi đã lớn, ta cứ nghĩ tin đồn cũng chỉ là truyền miệng, nay chúng dám cả gan giả dấu triều đình. Thật không thể chấp nhận được.”
+οTrần Thế Lục: “Nghe cho kỹ. Việc này tuyệt đối không để lọt. Cậu cầm ba phong thư này: một trao ông Thế Sương, một cho thầy thuốc Xuân Lang, một cho lão Tri. Cứ theo ngày trong đó, tụ họp ở nhà thuốc. Nhớ là với người khác thì kín chuyện như bưng, không được hé nửa lời.”
+•[target]
+1.Đến đình, trình thư cho Lý trưởng.
+2.Nhận ba phong thư mời họp.
+
+16. Giao thư 1 - Hơi thở an tĩnh
+•[mô tả] Mang thư của Lý trưởng đến cho Trần Thế Sương. Ông hướng dẫn ngồi tĩnh tâm, thiền.
+•[accept NPC] (Auto - sau khi nhận 3 phong thư)
+•[complete NPC] Trần Thế Sương
+•[dialog accept]
+οNhân vật chính: “Ông Lục dặn tôi mang tận tay cho ông.”
+οTrần Thế Sương: “Mặt mày cậu tái đi, mắt còn run. Giữ thư chưa kịp ấm tay đã lộ vẻ lo. Việc kín mà để lộ thế, khác nào hỏng.”
+οNhân vật chính: “…Tôi lo sợ lỡ sai, nên lòng chẳng yên.”
+οTrần Thế Sương: “Hầy… lòng rối thì bước run. Ngồi xuống đây.”
+οTrần Thế Sương: “Hít sâu vô, coi như hút gió sớm vào bụng. Giữ lại chút, như nước mưa đọng trong chum. Rồi thở ra chậm, cho nó lùa hơi nóng ra ngoài. Làm lại. Đừng vội.”
+• [dialog complete]
+οTrần Thế Sương: “Thân trẻ mà bụng nóng vội, hơi chẳng ở yên.”
+οTrần Thế Sương: “Tâm có an thì thân mới yên ổn. Hôm nay ngươi đã bị cuốn vào chuyện này, ngày sau sẽ còn nhiều chuyện phải lo. Cố mà giữ cho mình cái định, cái hơi thở. Tre còn biết nghiêng theo nhịp gió, huống chi người.” 
+οTrần Thế Sương: “Đủ rồi. Thư ta nhận. Cậu đi cho kịp.” 
+•[target]
+1.Đến sân tập gặp Trần Thế Sương.
+2.Trao thư mời họp.
+3.Ngồi xuống, tập thiền theo lời dạy.
+
+17.Giao thư 2 – Thỏ xào và lá thuốc
+•[mô tả] Đưa thư cho Xuân Lang. Ra vườn hái lá, bứt lá chuối, bắt thỏ. Học chế thuốc cầm máu, ăn món thỏ xào thảo dược của Quỳnh.
+•[accept NPC]  
+•[complete NPC]  
+•[dialog accept]
+οNhân vật chính: “Chào thầy Xuân Lang. Ông Lục dặn tôi mang phong thư này tới tận tay thầy.”
+οTrần Xuân Lang: “Đưa đây cho ta.” 
+οTrần Xuân Lang: “Nhưng ngươi, còn trẻ, lại bị cuốn vào việc này… Đường phía trước dài lắm.”
+οNhân vật chính: “Thầy… tôi nghe mà cũng lo. Nhưng ông Lục giao thì tôi phải làm thôi.”
+οTrần Xuân Lang: “Ờ, người trẻ thì phải gánh phần người trẻ. Có vậy mới nên chuyện.” 
+οTrần Xuân Quỳnh: “Thầy ơi, trong hũ thuốc cầm máu còn chút xíu, thiếu lá gấu rồi!”
+οTrần Xuân Lang: “Này, nếu có tiện thì ngươi ra vườn bứt cho ta ít lá gấu, thêm vài tàu chuối non. Ta bày cách làm thuốc luôn để sau này hoạn nạn có cách tự cứu lấy thân. Cả thêm vài con thỏ nữa, ta bảo Quỳnh làm cho ngươi một phần thịt để ăn cho lại sức, chặn đường tới đây ngươi sẽ vất vả nhiều.” 
+•[dialog complete]
+οTrần Xuân Lang: “Nhanh thế đã về rồi cơ à? Tốt lắm, đưa cho ta.”
+οTrần Xuân Lang: “Đập nhỏ rễ này, trộn với cỏ gấu, gói trong lá chuối. Bị thương thì chườm vào, máu sẽ dừng. Nhớ kỹ, đơn giản vậy thôi, Thuốc nam không khó, cái chính là chịu để ý.” 
+οTrần Xuân Quỳnh: “Còn đây là phần thịt thỏ ban nảy, tôi có bỏ thêm ít cỏ thuốc, nên thơm mà hơi đắng. Ăn vô người khỏe, đầu óc cũng tỉnh.” 
+οTrần Xuân Lang: “Được rồi, lấy sức xong rồi mau lo chuyện còn lại đi.” 
+•[target] 
+οGiao thư cho Trần Xuân Lang
+οThu thập lá cỏ gấu và lá chuối
+οBắt thỏ
+οĂn món thỏ xào thảo dược
+
+18.Giao thư 3 – Gậy già chờ tay
+•mô tả: Mang thư mời họp kín đến cho lão Trần Tri.
+•accept NPC: (Auto – sau khi nhận 3 thư)
+•complete NPC: Lão Trần Tri
+•dialog accept
+οNhân vật chính: “Chào lão Tri. Ông Lục dặn tôi mang thư này tới tận tay lão.”
+οLão Trần Tri: “Ờ, cám ơn cậu. Già rồi, mắt kèm nhèm, đọc thư cũng mất hơi lâu… khoan đã… ừm.”
+οLão Trần Tri: “Cái gậy của ta cũng có tuổi rồi, chuyện lớn thế này sợ nó không theo được xa. Cái thân già này không có gậy thì như cua cụt càng, ra đình coi bộ khó quá.”
+οNhân vật chính: “Lão còn phải đi họp, gậy lại thế này… Vậy biết làm sao?”
+οLão Trần Tri: “Ờ thì… cũng chỉ biết ngồi đây than. Gậy này theo ta mấy chục năm, giờ nó chịu thua. Đáng lẽ ta tự lo được, mà chân run tay mỏi rồi.”
+οNhân vật chính: “Nếu cần, tôi thử chạy sang nhà ông Mục xem sao. Ông ấy khéo tay nghề gỗ, biết đâu làm cho lão cái gậy mới.”
+οLão Trần Tri: “Ừ, cũng phải. Thằng Mục xưa nay làm chắc. Nhưng nhớ dặn nó… kiếm được khúc lim nhỏ nào thì tốt. Chắc thì già này mới dám bước ra đình, không thì đi giữa đường ngã thì mất mặt lắm.”
+•dialog complete
+οNhân vật chính: “Được, để tôi ghé ông Mục thử bàn. Tôi cũng mong lão có gậy chắc để chống đi cho yên bụng.”
+οLão Trần Tri: “Ờ, nhờ cậu vậy. Già này chẳng dám sai bảo, chỉ mong còn chống được cái thân đi họp với anh em bô lão. Có cậu trẻ giúp, ta cũng yên dạ phần nào.”
+οNhân vật chính: “Lão đừng lo, tôi sẽ cố chạy cho kịp.”
+•target
+οĐến nhà lão Trần Tri.
+οTrao thư. 
+
+19. Lời đồn rừng tây
+•mô tả: Tới xưởng gỗ, hỏi chỗ có gỗ lim nhỏ phù hợp.
+•accept NPC: (Auto)
+•complete NPC: Trần Đăng Mục
+•dialog accept
+οNhân vật chính: “Chào bác Mục, tôi vừa ở bên lão Tri qua. Lão bảo cái gậy cũ mục hết rồi, chống vài bước là gãy. Nên tôi sang nhờ bác giúp làm cho lão cái gậy mới.”
+οTrần Đăng Mục: “Ờ… già Tri vẫn còn ương cứng lắm. Gậy nứt từ đời nào cũng ôm khư khư, tới lúc gãy rắc rồi mới nhờ. Nhưng mà… gậy lim thì chắc, còn giờ lim trong xưởng này thì sạch trơn.”
+οNhân vật chính: “Không còn khúc nào dư sao, bác?”
+οTrần Đăng Mục: “Gỗ tạp thì nhiều, chỗ nào cũng có. Nhưng lim thì hiếm lắm. Đâu ngoài bìa rừng phía tây còn mấy cây nhỏ. Chỉ tội… người ta đồn ở đó có ma lai, nên ai cũng ngán, chẳng dám bén mảng.”
+οNhân vật chính: “Ma lai thật hả bác? Tôi nghe bác nói thôi, chưa rõ thế nào.”
+οTrần Đăng Mục: “Thật giả thì ai mà biết. Ta thì xưa nay chỉ tin vào mắt mình. Nhưng cái chân này mấy bữa nay sưng, bước còn nhói, có muốn lội vô rừng cũng chịu. Mà bọn người làm, nghe tin đồn xong cũng đâu dám thử vào.”
+οNhân vật chính: “Nếu tôi liều thử, lấy được khúc lim mang về… bác có chịu làm cho lão Tri không?”
+οTrần Đăng Mục: “Ờ, mang về được thì ta làm ngay. Đầu bịt sắt, thân chắc, lão Tri có chống thì cũng khỏi lo gãy.”
+οNhân vật chính: “Tôi nghe bác nói, cũng hơi rợn. Nhưng nếu không có gậy, lão Tri làm sao mà tới đình. Tôi sẽ thử.”
+•dialog complete
+οTrần Đăng Mục: “Khá đấy. Mà về tin đồn kia, việc âm dương thì ta không rành. Ngươi muốn yên tâm thì qua hỏi bà Mắm. Bả tuy mê tín, nhưng cũng rành mấy cái mẹo của ông bà xưa nay.”
+οTrần Đăng Mục: “Lim mà mang về được, ta hứa làm cho ra cây gậy chắc, già Tri chống mà cũng vênh mặt với thiên hạ.”
+•target
+οTới xưởng gỗ.
+οTrò chuyện với Trần Đăng Mục. 
+
+20.Tìm mẹo trấn âm
+•mô tả: Hỏi bà Mắm mẹo tránh tà khí khi vào rừng tây.
+•accept NPC: (Auto)
+•complete NPC: Bà Mắm
+•dialog accept
+οNhân vật chính: “Bà Mắm, tôi nghe người ta kháo… rìa rừng tây có chuyện lạ. Bà hay để ý mấy chuyện tâm linh, bà có nghe thấy gì không?”
+οBà Mắm: “Hầy, cậu trẻ này… hỏi chi toàn chuyện gở. Làng này ai chả xì xào. Người thì bảo nghe tiếng cười the thé, người thì thề thấy bóng đen bay là là mặt đất. Nghe mà dựng tóc gáy.”
+οNhân vật chính: “Thế bà tin là có thật sao?”
+οBà Mắm: “Tin với chả không tin… Ngày trước, có thằng con ông thợ mộc… coi thường, chẳng chịu nghe, cứ vác rìu vô rừng một mình. Người ta thấy nó về, mắt lạc thần, người như mất hồn. Nằm một đêm, sáng ra lạnh ngắt. Từ đó… chẳng ai dám bước chân vô mà tay không. Già đây xưa giờ cũng hay gặp, mấy chuyện thế này nên tránh, có kiêng có lành cậu ơi.”
+οNhân vật chính: “Tôi có việc phải vào. Nhưng nghe đồn vậy, lòng cũng không yên.”
+οBà Mắm: “Thân trai mà đi chỗ âm u đó, gan có to mấy cũng dễ bị hớp vía. Người ta bảo, ma quỷ nó ưa hơi lạnh, gặp người yếu bóng, nó lùa cái là đổ bệnh ngay.”
+οNhân vật chính: “Bà có biết cách nào… cho yên bụng hơn không?”
+οBà Mắm: “Ờ… cũng có mẹo truyền lại của ông bà thôi. Không phép thánh gì đâu. Người ta nói ma thì âm, muốn át nó thì phải mang thứ cực dương theo người.”
+οNhân vật chính: “Cực dương là thứ gì?”
+οBà Mắm: “Dân gian tin rằng… trứng gà vừa đẻ, còn nóng hổi, với lại… nước tiểu trẻ con. Nghe thì dơ, mà nó là dương khí thuần khiết.” 
+οBà Mắm:“Trứng gà ở đây thì thiếu gì. Ra sân đá gà mà tìm thằng Trần Kê, nhà nó nuôi cả bầy gà chọi, ổ nào chả có. Còn trẻ con… ờ, ra bờ sông hỏi thằng cu Lỳ. Nó còn nhỏ, suốt ngày ngồi câu cá, vô tư lắm. Nó là cháu ta, cứ ra nói với nó là ta bảo ngươi, nó sẽ biết thôi.”
+•dialog complete
+οNhân vật chính: “Tôi cảm ơn bà. Tôi sẽ nhớ lời dặn.”
+οBà Mắm: “Ơn nghĩa gì. Ta chỉ nói cái ta nghe. Còn đi hay không, là gan cậu.”
+•target
+οĐến sạp bà Mắm.
+οHỏi chuyện bà Mắm. 
+
+21.Mồi cá bên sông
+•mô tả: Ra bờ sông gặp cu Lỳ.
+•accept NPC: (Auto)
+•complete NPC: Cu Lỳ
+•dialog accept
+οNhân vật chính: “Lỳ, hôm nay được con nào chưa?”
+οCu Lỳ: “Được ba con rô rồi. Tối nay mẹ kho chắc hết sạch cơm.”
+οNhân vật chính: “Khá thật. Ngồi cả buổi, không chán à?”
+οCu Lỳ: “Không. Ngồi coi phao cũng vui. Ngồi đây vừa mát vừa yên tĩnh, ngồi lâu có mắc thì đi thẳng ra sông luôn cũng tiện nữa.”  
+οNhân vật chính: “Chuyện là... bà Mắm bảo ta sang đây tìm ngươi để...”
+οCu Lỳ: “Ơ kìa,... Ta hiểu rồi, mà bác cũng tin mấy chuyện đó à? Nhưng thôi, bác muốn thì được. Nhưng bác ngồi đây đi, giờ ta chưa buồn đi.”
+•dialog complete
+οĐây, lấy cái ống đựng mồi này mà giữ, coi chừng đổ ra kẻo thối um nhé.  
+•target
+οĐến bờ sông.
+οNói chuyện với Cu Lỳ.
+οNgồi chờ.
+οNhận ống tre chứa nước tiểu đồng tử.
+
+22.Cựa gà trên sân
+•mô tả: Đến sân đá gà, theo kèo Trần Kê gợi ý, xin trứng tươi.
+•accept NPC: (Auto)
+•complete NPC: Trần Kê
+•dialog accept
+οTrần Kê: “Ô Mắt Lửa! Đâm vô! Đấy, một cựa thôi mà nó lảo đảo rồi! Ha ha, coi kìa, coi kìa!”
+οTrần Kê: “Thấy chưa! Gà nhà ta nuôi từ trong trứng, ăn thóc rang, ăn nghệ, ngủ còn có khăn phủ. Giờ ra sân, nó cắn phát nào là đối thủ bỏng phát đó!”
+οNhân vật chính: “Đúng là gà bác nuôi khác hẳn. Đá hiểm, gan lì, coi mà lạnh sống lưng. Người nuôi cũng giỏi lắm… nhìn như này chắc là tuyển chọn từ còn trong trứng nhỉ?”
+οTrần Kê: “Ờ, trứng mà không chắc thì đừng mong nở gà chiến. Ổ nào ta cũng bới từng quả, nâng như nâng vàng. Người ta chọn gà khi lớn, còn tôi chọn ngay từ trong ổ!”
+οNhân vật chính: “Nghe anh nói… tôi cũng muốn được hưởng chút vía gà hay. Nếu có thể… cho tôi xin một hai quả, coi như mang theo cho gặp may.”
+•dialog complete
+οTrần Kê: “Ha ha! Nói năng khéo đấy. Sáng nay ổ gà nhà ta cũng vừa đẻ, ta lựa mấy quả giữ lại rồi, còn đây có mang dư mấy quả chắc tay định ra chợ đổi chút đồ. Mà ngươi xin thì ta cho vài quả lấy may!”
+οTrần Kê: “Cầm lấy! Người ta bảo trứng đầu mùa giữ vía, đi đâu cũng có thần kê phù hộ. Coi như lộc gà của ta ban cho!”
+οNhân vật chính: “Đa tạ anh Kê. Có được lộc này, tôi yên dạ hơn.”
+οTrần Kê: “Ờ, giữ kỹ đấy. Rơi vỡ thì vía cũng tan. Ha! Mai nhớ ghé coi trận khác, ta cho coi con Bạc Mào. Nó còn dữ hơn con này nữa!”
+•target
+οTới sân đá gà.
+οNói chuyện với Trần Kê.
+οXem trận.
+οNhận trứng gà.
+
+23.Cực dương
+•mô tả: Pha chế theo lời bà Mắm.
+•accept NPC: (Auto)
+•complete NPC: Bà Mắm
+•dialog accept
+οBà Mắm: “Ơ kìa, nhanh thế mà đã mang về rồi sao. Được, trông cậu có vẻ quyết tâm cao đấy!”
+οNhân vật chính: “Con nghĩ, thà tin còn hơn ngờ. Vào rừng tây, con chẳng dám khinh thường.”
+•dialog complete
+οBà Mắm: “Được. Cả hai thứ hợp lại… chính là cực dương. Người xưa đi đêm, đi rừng, vẫn lấy làm bùa. Cậu mang trong người thì ma quái cũng phải né.” 
+•target
+οPha chế hỗn hợp. 
+
+24.Một cái đầu lơ lửng
+•mô tả: Vào bìa rừng tây, lần dấu tro/giẻ, đối mặt với ma lai.
+•accept NPC: (Auto)
+•complete NPC: (Auto)
+•dialog accept
+•dialog complete
+•target
+οVào rừng. 
+οĐối mặt và đánh bại ma lai.
+
+25.Khúc gỗ lim giữa rừng
+•mô tả: Chặt một cây gỗ và lấy gỗ về
+•accept NPC: (Auto)
+•complete NPC: (Auto)
+•dialog accept
+•dialog complete
+•target
+οChặt một cái cây và lấy gỗ
+
+26.Căn lều trong rừng sâu
+•mô tả: Phát hiện lều lạ, nghe thấy nhắc “Đại Hãn”, bị phát hiện, giao đấu, địch rút.
+•accept NPC: (Auto)
+•complete NPC: (Auto)
+•dialog accept
+οÁo đen A: “Cái kế của lão già đó hay thật, dùng phép gọi được hồn con ma lai lên ám cả khu này để không ai dám bén mảng tới làm phiền chúng ta.”
+οÁo đen B: “Quả thật là như vậy, cứ ở yên trong đây, biên thêm mớ giấy yết thị này rồi tuồng ra ngoài chợ, sớm thôi lòng thân cũng sẽ lay động.”
+οÁo đen A: “Cứ như thế, Đại Hãn cũng chẳng cần phải ra tay, mà lòng dân chúng cũng sẽ rời nhau cả hết.” 
+•dialog complete 
+•target 
+οTiếp cận căn lều lạ.
+οGiao đấu với bọn áo đen.
+
+27.Cây gỗ tốt
+•mô tả: Trả gỗ cho Mục, nhận gậy lim.
+•accept NPC: (Auto)
+•complete NPC: Trần Đăng Mục
+•dialog accept
+οTrần Đăng Mục: “Giời ơi, thật sự là giỏi quá! Vác được lim rừng về, lại là hàng tốt thế này, trời phú, quả thật là trời phú.”
+οTrần Đăng Mục: “Nghe đi, tiếng chắc như trống hội. Cây gỗ thế này, làm gậy thì đời đời không lo cong gãy.”
+•dialog complete
+οTrần Đăng Mục: “Cầm lấy. Mang về cho lão Tri. Có thanh gậy này, lão chắc vui hết phần đời còn lại.” 
+•target
+οGiao gỗ cho Trần Đăng Mục.
+οNhận gậy.
+
+28.Gậy chống làng
+•mô tả: Giao cây gậy mới cho ông Tri
+•accept NPC: (Auto)
+•complete NPC: Lão Trần Tri
+•dialog accept
+•dialog complete
+οTrần Tri: “Trong mấy năm nay, có lẽ đây là lần lão cảm thấy vui nhất. Cảm ơn, cảm ơn! Từ giờ lão có thể tiếp tục ngẫn cao đầu sải bước về đình rồi.”  
+•target
+οGiao gậy cho Trần Tri.
+
+29.Đêm họp dưới đèn
+•mô tả: Họp kín tại nhà thuốc Xuân Lang, trình bày thư giả, lều lạ. Lý trưởng phân công.
+•accept NPC: Lý trưởng Trần Thế Lục
+•complete NPC: Lý trưởng Trần Thế Lục
+•dialog accept 
+οNhân vật chính: “Các cụ nhớ tin đồn ma lai người ta nói về rừng phía tây chứ? Đúng là có thật, chính tôi đã đánh với nó. Nhưng nó là trò tà thuật của bọn áo đen đã hại tôi lần trước. Đằng sau khu đó có căn lều. Cùng với mấy kẻ lạ miệng luôn nhắc ‘Đại Hãn’, nhắc tung giấy giả. Tôi lộ mặt, chúng lao vào đánh định bịt đầu mối, nhưng chúng đánh không lại bèn dùng thủ thuật mà thoát. Còn sót lại… những giấy này.”
+οThế Sương: “Ha, đúng là trò của ta, mới đó thôi mà bọn chúng đánh không lại ngươi rồi., thử mà…”
+οXuân Lang: “Gượm đã lão Sương, ông nhìn giấy này đi, giấy lạ, mực lạ. Hệt với tờ hôm trước dân ta truyền ngoài chợ, rõ không phải đồ của làng. Rõ là có kẻ muốn cố ý gieo loạn lòng dân.”
+οThế Sương: “Chậc, lòng dân mà lung thay thì, có luyện binh lực bao nhiêu cũng vô ích. Giặc chẳng cần đánh, lòng đã tan. Quả thật là kế hiểm.”
+οTrần Tri: “Năm xưa, ta đã thấy lửa cháy đỏ sông, xác người nổi trắng. Nay lại nghe ‘Đại Hãn’… Thật là lạnh cả xương sống.”
+•dialog complete
+οTrần Thế Lục: “Những chuyện thế này là việc của mấy lão già bọn ta, bởi lời bọn ta ít ra có sức nặng, dễ bề mà làm rõ, làm tỉnh lại lòng dân. Thế nhưng ngươi thân trẻ mà lại bị cuốn vào trực tiếp như vậy. Thật khó tránh, khó tránh khỏi mà. Được rồi, vậy thì ngươi phải cùng mấy ông già này xử lý việc này thôi. Hành sự sắp tới sẽ khó khăn, ngươi về chuẩn bị thêm một thời gian. Thời cơ chín mùi ta sẽ cho gọi.”
+•target
+οĐến nhà thuốc.
+οHọp cùng các bô lão.
+
+30.Những ngày chuẩn bị
+Trải qua nhiều ngày luyện côn với Thế Sương, tập thở thiền, nhận thuốc cầm máu, bánh lá dong và lời dặn dò.
+► Yêu cầu farm, làm nhiệm vụ phụ, ... khi đạt đủ cấp mở chương nhiệm vụ mới thì mới lên đường 
+

--- a/packaging/questtools_ui.spec
+++ b/packaging/questtools_ui.spec
@@ -1,0 +1,60 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec file for building the QuestTools UI launcher."""
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
+
+project_root = Path(__file__).resolve().parent.parent
+
+_datas = [
+    (str(project_root / "questtools" / "web" / "templates"), "questtools/web/templates"),
+    (str(project_root / "questtools" / "web" / "static"), "questtools/web/static"),
+    (str(project_root / "data" / "quests" / "tan_thu.json"), "data/quests"),
+]
+
+_hiddenimports = []
+for package in ["questtools", "uvicorn", "fastapi", "starlette", "pydantic"]:
+    _hiddenimports.extend(collect_submodules(package))
+
+block_cipher = None
+
+
+a = Analysis(
+    [str(project_root / "questtools" / "ui_launcher.py")],
+    pathex=[str(project_root)],
+    binaries=[],
+    datas=_datas,
+    hiddenimports=_hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="QuestToolsUI",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)

--- a/questtools/__init__.py
+++ b/questtools/__init__.py
@@ -1,0 +1,6 @@
+"""QuestTools package for managing quest documents."""
+
+from .models import Quest, QuestDocument
+from .storage import load_document, save_document
+
+__all__ = ["Quest", "QuestDocument", "load_document", "save_document"]

--- a/questtools/__main__.py
+++ b/questtools/__main__.py
@@ -1,0 +1,13 @@
+"""Entry point for running QuestTools as a module."""
+
+from .cli import main
+
+
+def run() -> None:
+    """Execute the CLI."""
+
+    main()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/questtools/cli.py
+++ b/questtools/cli.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from .models import Quest, QuestDocument
 from .parser import parse_document
 from .storage import load_document, save_document
+from .server import run_server
 
 
 def _load_or_empty(path: Path) -> QuestDocument:
@@ -159,6 +160,10 @@ def cmd_remove(args: argparse.Namespace) -> None:
     print(f"Removed quest {args.id}")
 
 
+def cmd_serve(args: argparse.Namespace) -> None:
+    run_server(Path(args.data), host=args.host, port=args.port, open_browser=args.open)
+
+
 def cmd_show(args: argparse.Namespace) -> None:
     path = Path(args.data)
     document = load_document(path)
@@ -214,6 +219,13 @@ def build_parser() -> argparse.ArgumentParser:
     remove_parser.add_argument("data", help="Quest JSON data file")
     remove_parser.add_argument("id", type=int, help="Quest identifier")
     remove_parser.set_defaults(func=cmd_remove)
+
+    serve_parser = subparsers.add_parser("serve", help="Launch the management web UI")
+    serve_parser.add_argument("data", help="Quest JSON data file")
+    serve_parser.add_argument("--host", default="127.0.0.1")
+    serve_parser.add_argument("--port", type=int, default=8000)
+    serve_parser.add_argument("--open", action="store_true", help="Open the interface in a browser")
+    serve_parser.set_defaults(func=cmd_serve)
 
     return parser
 

--- a/questtools/cli.py
+++ b/questtools/cli.py
@@ -1,0 +1,231 @@
+"""Command line interface for QuestTools."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from .models import Quest, QuestDocument
+from .parser import parse_document
+from .storage import load_document, save_document
+
+
+def _load_or_empty(path: Path) -> QuestDocument:
+    if path.exists():
+        return load_document(path)
+    return QuestDocument(title=None, overview="", quests=[])
+
+
+def _print_quest(quest: Quest) -> None:
+    print(f"Quest {quest.id}: {quest.title}")
+    if quest.description:
+        print(f"  Description: {quest.description}")
+    if quest.accept_npc:
+        print(f"  Accept NPC: {quest.accept_npc}")
+    if quest.complete_npc:
+        print(f"  Complete NPC: {quest.complete_npc}")
+    if quest.dialog_accept:
+        print("  Dialog (accept):")
+        for line in quest.dialog_accept:
+            print(f"    - {line}")
+    if quest.dialog_complete:
+        print("  Dialog (complete):")
+        for line in quest.dialog_complete:
+            print(f"    - {line}")
+    if quest.targets:
+        print("  Targets:")
+        for line in quest.targets:
+            print(f"    - {line}")
+    if quest.notes:
+        print("  Notes:")
+        for line in quest.notes:
+            print(f"    - {line}")
+    if quest.extra_fields:
+        print("  Extra fields:")
+        for key, value in quest.extra_fields.items():
+            print(f"    {key}: {value}")
+
+
+def cmd_convert(args: argparse.Namespace) -> None:
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    text = input_path.read_text(encoding="utf-8")
+    document = parse_document(text)
+    if args.title:
+        document.title = args.title
+    save_document(output_path, document)
+    print(f"Converted {input_path} -> {output_path}")
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    path = Path(args.data)
+    document = load_document(path)
+
+    print(f"Document: {document.title or 'Untitled'}")
+    print(f"Overview length: {len(document.overview.splitlines())} lines")
+    print("Quests:")
+    for quest in sorted(document.quests, key=lambda q: q.id):
+        accept = f" (accept: {quest.accept_npc})" if quest.accept_npc else ""
+        print(f"  {quest.id:>2}: {quest.title}{accept}")
+
+
+def _parse_list_argument(values: Optional[List[str]]) -> Optional[List[str]]:
+    if values is None:
+        return None
+    return [value.strip() for value in values if value.strip()]
+
+
+def cmd_add(args: argparse.Namespace) -> None:
+    path = Path(args.data)
+    document = _load_or_empty(path)
+
+    next_id = max([quest.id for quest in document.quests], default=0) + 1
+    quest = Quest(id=next_id, title=args.title)
+
+    if args.description:
+        quest.description = args.description
+    if args.accept_npc:
+        quest.accept_npc = args.accept_npc
+    if args.complete_npc:
+        quest.complete_npc = args.complete_npc
+
+    dialog_accept = _parse_list_argument(args.dialog_accept)
+    if dialog_accept:
+        quest.dialog_accept = dialog_accept
+
+    dialog_complete = _parse_list_argument(args.dialog_complete)
+    if dialog_complete:
+        quest.dialog_complete = dialog_complete
+
+    targets = _parse_list_argument(args.targets)
+    if targets:
+        quest.targets = targets
+
+    notes = _parse_list_argument(args.notes)
+    if notes:
+        quest.notes = notes
+
+    document.quests.append(quest)
+    save_document(path, document)
+    print(f"Added quest {quest.id}: {quest.title}")
+
+
+def _find_quest(document: QuestDocument, quest_id: int) -> Quest:
+    for quest in document.quests:
+        if quest.id == quest_id:
+            return quest
+    raise SystemExit(f"Quest with id {quest_id} not found")
+
+
+def cmd_update(args: argparse.Namespace) -> None:
+    path = Path(args.data)
+    document = load_document(path)
+    quest = _find_quest(document, args.id)
+
+    if args.title:
+        quest.title = args.title
+    if args.description is not None:
+        quest.description = args.description
+    if args.accept_npc is not None:
+        quest.accept_npc = args.accept_npc
+    if args.complete_npc is not None:
+        quest.complete_npc = args.complete_npc
+
+    if args.dialog_accept is not None:
+        quest.dialog_accept = _parse_list_argument(args.dialog_accept) or []
+    if args.dialog_complete is not None:
+        quest.dialog_complete = _parse_list_argument(args.dialog_complete) or []
+    if args.targets is not None:
+        quest.targets = _parse_list_argument(args.targets) or []
+    if args.notes is not None:
+        quest.notes = _parse_list_argument(args.notes) or []
+
+    save_document(path, document)
+    print(f"Updated quest {quest.id}: {quest.title}")
+
+
+def cmd_remove(args: argparse.Namespace) -> None:
+    path = Path(args.data)
+    document = load_document(path)
+    before = len(document.quests)
+    document.quests = [quest for quest in document.quests if quest.id != args.id]
+    after = len(document.quests)
+    if before == after:
+        raise SystemExit(f"Quest with id {args.id} not found")
+    save_document(path, document)
+    print(f"Removed quest {args.id}")
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    path = Path(args.data)
+    document = load_document(path)
+    quest = _find_quest(document, args.id)
+    _print_quest(quest)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Quest management utilities")
+    subparsers = parser.add_subparsers(dest="command")
+
+    convert_parser = subparsers.add_parser("convert", help="Convert a raw document to JSON")
+    convert_parser.add_argument("input", help="Path to the raw text document")
+    convert_parser.add_argument("output", help="Output JSON file")
+    convert_parser.add_argument("--title", help="Override document title", default=None)
+    convert_parser.set_defaults(func=cmd_convert)
+
+    list_parser = subparsers.add_parser("list", help="List quests in a data file")
+    list_parser.add_argument("data", help="Quest JSON data file")
+    list_parser.set_defaults(func=cmd_list)
+
+    show_parser = subparsers.add_parser("show", help="Show a quest in detail")
+    show_parser.add_argument("data", help="Quest JSON data file")
+    show_parser.add_argument("id", type=int, help="Quest identifier")
+    show_parser.set_defaults(func=cmd_show)
+
+    add_parser = subparsers.add_parser("add", help="Add a new quest")
+    add_parser.add_argument("data", help="Quest JSON data file")
+    add_parser.add_argument("title", help="Title for the new quest")
+    add_parser.add_argument("--description")
+    add_parser.add_argument("--accept-npc")
+    add_parser.add_argument("--complete-npc")
+    add_parser.add_argument("--dialog-accept", action="append", help="Dialog lines for accepting")
+    add_parser.add_argument("--dialog-complete", action="append", help="Dialog lines for completion")
+    add_parser.add_argument("--targets", action="append", help="Quest targets")
+    add_parser.add_argument("--notes", action="append", help="Additional notes")
+    add_parser.set_defaults(func=cmd_add)
+
+    update_parser = subparsers.add_parser("update", help="Update an existing quest")
+    update_parser.add_argument("data", help="Quest JSON data file")
+    update_parser.add_argument("id", type=int, help="Quest identifier")
+    update_parser.add_argument("--title")
+    update_parser.add_argument("--description")
+    update_parser.add_argument("--accept-npc")
+    update_parser.add_argument("--complete-npc")
+    update_parser.add_argument("--dialog-accept", action="append")
+    update_parser.add_argument("--dialog-complete", action="append")
+    update_parser.add_argument("--targets", action="append")
+    update_parser.add_argument("--notes", action="append")
+    update_parser.set_defaults(func=cmd_update)
+
+    remove_parser = subparsers.add_parser("remove", help="Remove a quest")
+    remove_parser.add_argument("data", help="Quest JSON data file")
+    remove_parser.add_argument("id", type=int, help="Quest identifier")
+    remove_parser.set_defaults(func=cmd_remove)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv[1:])

--- a/questtools/models.py
+++ b/questtools/models.py
@@ -1,0 +1,45 @@
+"""Data models for representing quest documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Quest:
+    """Represent a single quest entry."""
+
+    id: int
+    title: str
+    description: Optional[str] = None
+    accept_npc: Optional[str] = None
+    complete_npc: Optional[str] = None
+    dialog_accept: List[str] = field(default_factory=list)
+    dialog_complete: List[str] = field(default_factory=list)
+    targets: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+    extra_fields: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Convert the quest to a serialisable dictionary."""
+
+        return asdict(self)
+
+
+@dataclass
+class QuestDocument:
+    """Representation of an entire quest document."""
+
+    title: Optional[str]
+    overview: str
+    quests: List[Quest] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Convert the document to a serialisable dictionary."""
+
+        return {
+            "title": self.title,
+            "overview": self.overview,
+            "quests": [quest.to_dict() for quest in self.quests],
+        }

--- a/questtools/parser.py
+++ b/questtools/parser.py
@@ -1,0 +1,166 @@
+"""Parser utilities for converting quest documents from plain text."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from .models import Quest, QuestDocument
+
+QUEST_HEADER_PATTERN = re.compile(r"^(?P<id>\d+)\.\s*(?P<title>.+)$")
+
+
+def _normalise_label(label: str) -> str:
+    """Convert a label to a simplified ascii identifier."""
+
+    normalised = unicodedata.normalize("NFKD", label).encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"\s+", " ", normalised).strip().lower()
+
+
+_FIELD_MAP: Dict[str, Tuple[str, str]] = {
+    "mo ta": ("description", "single"),
+    "mo ta ": ("description", "single"),
+    "description": ("description", "single"),
+    "accept npc": ("accept_npc", "single"),
+    "accept": ("accept_npc", "single"),
+    "complete npc": ("complete_npc", "single"),
+    "complete": ("complete_npc", "single"),
+    "dialog accept": ("dialog_accept", "list"),
+    "dialog accept ": ("dialog_accept", "list"),
+    "dialog complete": ("dialog_complete", "list"),
+    "dialog finish": ("dialog_complete", "list"),
+    "dialog": ("dialog_accept", "list"),
+    "target": ("targets", "list"),
+    "target 1": ("targets", "list"),
+    "target 2": ("targets", "list"),
+    "targets": ("targets", "list"),
+}
+
+_LIST_FIELDS = {"dialog_accept", "dialog_complete", "targets"}
+
+
+@dataclass
+class _ParseState:
+    quest: Quest
+    current_field: Optional[str] = None
+
+
+def _parse_line(state: _ParseState, label: str, value: str) -> None:
+    field_info = _FIELD_MAP.get(label)
+    if field_info:
+        field_name, field_type = field_info
+        state.current_field = field_name if field_type == "list" else None
+
+        if field_type == "list":
+            entries = [value] if value else []
+            getattr(state.quest, field_name).extend(filter(None, [entry.strip() for entry in entries]))
+        else:
+            if value:
+                existing = getattr(state.quest, field_name)
+                if existing:
+                    merged = f"{existing}\n{value.strip()}"
+                else:
+                    merged = value.strip()
+                setattr(state.quest, field_name, merged)
+    else:
+        if value:
+            state.quest.extra_fields[label] = value.strip()
+        state.current_field = None
+
+
+def _append_to_current(state: _ParseState, line: str) -> None:
+    if state.current_field and state.current_field in _LIST_FIELDS:
+        getattr(state.quest, state.current_field).append(line.strip())
+    else:
+        if line.strip():
+            state.quest.notes.append(line.strip())
+
+
+def parse_document(text: str) -> QuestDocument:
+    """Parse a quest document from the provided raw text."""
+
+    lines = [line.rstrip() for line in text.splitlines()]
+
+    preamble_lines: List[str] = []
+    quests: List[Quest] = []
+    current_state: Optional[_ParseState] = None
+    in_quests = False
+    detail_section_reached = False
+
+    for line in lines:
+        stripped = line.strip()
+        normalised_line = _normalise_label(stripped) if stripped else ""
+
+        if not detail_section_reached:
+            preamble_lines.append(line)
+            if normalised_line == "chi tiet":
+                detail_section_reached = True
+            continue
+
+        if not in_quests:
+            header_match = QUEST_HEADER_PATTERN.match(stripped)
+            if header_match:
+                in_quests = True
+            else:
+                preamble_lines.append(line)
+                continue
+
+        quest_match = QUEST_HEADER_PATTERN.match(stripped)
+        if in_quests and quest_match:
+            quest_id = int(quest_match.group("id"))
+            if current_state is None or quest_id > current_state.quest.id:
+                if current_state is not None:
+                    quests.append(current_state.quest)
+                title = quest_match.group("title").strip()
+                current_state = _ParseState(quest=Quest(id=quest_id, title=title))
+                continue
+
+        if current_state is None:
+            continue
+
+        if not stripped:
+            current_state.current_field = None
+            continue
+
+        if stripped.startswith("•") or stripped.startswith("-"):
+            content = stripped[1:].strip()
+            if content.startswith("[") and "]" in content:
+                label_part, rest = content.split("]", 1)
+                label = label_part[1:].strip()
+                value = rest.strip()
+                normalised = _normalise_label(label)
+                _parse_line(current_state, normalised, value)
+            else:
+                if content:
+                    current_state.quest.notes.append(content)
+                current_state.current_field = None
+            continue
+
+        if stripped.startswith("o"):
+            content = stripped[1:].strip(" \t-•")
+            if content:
+                _append_to_current(current_state, content)
+            continue
+
+        if stripped.startswith("→"):
+            current_state.quest.notes.append(stripped)
+            continue
+
+        _append_to_current(current_state, stripped)
+
+    if current_state is not None:
+        quests.append(current_state.quest)
+
+    title: Optional[str] = None
+    overview = ""
+    if preamble_lines:
+        non_empty = [line for line in preamble_lines if line.strip()]
+        if non_empty:
+            title = non_empty[0].strip()
+        overview = "\n".join(preamble_lines).strip()
+
+    quests.sort(key=lambda q: q.id)
+
+    return QuestDocument(title=title, overview=overview, quests=quests)

--- a/questtools/repository.py
+++ b/questtools/repository.py
@@ -1,0 +1,144 @@
+"""High-level repository for quest data persistence."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, Iterable, Optional
+
+from .models import Quest, QuestDocument
+from .storage import load_document, save_document
+
+
+class QuestRepository:
+    """Provide thread-safe access to quest documents."""
+
+    _QUEST_FIELDS = {
+        "title",
+        "description",
+        "accept_npc",
+        "complete_npc",
+        "dialog_accept",
+        "dialog_complete",
+        "targets",
+        "notes",
+        "extra_fields",
+    }
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self._lock = Lock()
+        self._document: Optional[QuestDocument] = None
+
+    def _ensure_document(self) -> QuestDocument:
+        if self._document is None:
+            if self.path.exists():
+                self._document = load_document(self.path)
+            else:
+                self._document = QuestDocument(title=None, overview="", quests=[])
+        return self._document
+
+    def _persist(self) -> None:
+        document = self._ensure_document()
+        save_document(self.path, document)
+
+    def _clone(self, document: QuestDocument) -> QuestDocument:
+        return deepcopy(document)
+
+    def _clone_quest(self, quest: Quest) -> Quest:
+        return deepcopy(quest)
+
+    def get_document(self) -> QuestDocument:
+        with self._lock:
+            document = self._ensure_document()
+            return self._clone(document)
+
+    def list_quests(self) -> Iterable[Quest]:
+        document = self.get_document()
+        return document.quests
+
+    def _find_quest(self, document: QuestDocument, quest_id: int) -> Quest:
+        for quest in document.quests:
+            if quest.id == quest_id:
+                return quest
+        raise KeyError(f"Quest with id {quest_id} not found")
+
+    def get_quest(self, quest_id: int) -> Quest:
+        with self._lock:
+            document = self._ensure_document()
+            quest = self._find_quest(document, quest_id)
+            return self._clone_quest(quest)
+
+    def _next_id(self, document: QuestDocument) -> int:
+        if not document.quests:
+            return 1
+        return max(quest.id for quest in document.quests) + 1
+
+    def create_quest(self, data: Dict[str, Any]) -> Quest:
+        if not data.get("title"):
+            raise ValueError("Quest title is required")
+
+        with self._lock:
+            document = self._ensure_document()
+            quest = Quest(id=self._next_id(document), title=str(data["title"]))
+
+            for field in self._QUEST_FIELDS - {"title"}:
+                if field in data and data[field] is not None:
+                    setattr(quest, field, self._normalise_field(field, data[field]))
+
+            document.quests.append(quest)
+            self._persist()
+            return self._clone_quest(quest)
+
+    def update_quest(self, quest_id: int, data: Dict[str, Any]) -> Quest:
+        with self._lock:
+            document = self._ensure_document()
+            quest = self._find_quest(document, quest_id)
+
+            if "title" in data and data["title"] is not None:
+                quest.title = str(data["title"])
+
+            for field in self._QUEST_FIELDS - {"title"}:
+                if field in data:
+                    value = data[field]
+                    if value is None:
+                        if isinstance(getattr(quest, field), list):
+                            setattr(quest, field, [])
+                        else:
+                            setattr(quest, field, None)
+                    else:
+                        setattr(quest, field, self._normalise_field(field, value))
+
+            self._persist()
+            return self._clone_quest(quest)
+
+    def delete_quest(self, quest_id: int) -> None:
+        with self._lock:
+            document = self._ensure_document()
+            original_length = len(document.quests)
+            document.quests = [quest for quest in document.quests if quest.id != quest_id]
+            if len(document.quests) == original_length:
+                raise KeyError(f"Quest with id {quest_id} not found")
+            self._persist()
+
+    def update_document(self, *, title: Optional[str], overview: str) -> QuestDocument:
+        with self._lock:
+            document = self._ensure_document()
+            document.title = title
+            document.overview = overview
+            self._persist()
+            return self._clone(document)
+
+    def _normalise_field(self, field: str, value: Any) -> Any:
+        if field in {"dialog_accept", "dialog_complete", "targets", "notes"}:
+            if isinstance(value, str):
+                return [item for item in value.splitlines() if item.strip()]
+            if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+                return [str(item) for item in value]
+            raise TypeError(f"Invalid value for {field}: {value!r}")
+        if field == "extra_fields":
+            if not isinstance(value, dict):
+                raise TypeError("extra_fields must be a mapping")
+            return {str(k): str(v) for k, v in value.items()}
+        return value

--- a/questtools/server.py
+++ b/questtools/server.py
@@ -1,0 +1,40 @@
+"""Utilities to run the QuestTools web server."""
+
+from __future__ import annotations
+
+import threading
+import time
+import webbrowser
+from pathlib import Path
+from .repository import QuestRepository
+from .web import create_app
+
+
+def run_server(
+    data_path: Path | str,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    open_browser: bool = False,
+) -> None:
+    """Start the QuestTools FastAPI server."""
+
+    app_path = Path(data_path)
+    repository = QuestRepository(app_path)
+    app = create_app(repository, data_path=app_path.resolve())
+
+    if open_browser:
+        url = f"http://{host}:{port}/"
+
+        def _open() -> None:
+            time.sleep(1.0)
+            webbrowser.open(url)
+
+        threading.Thread(target=_open, daemon=True).start()
+
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover - runtime guard
+        raise RuntimeError("uvicorn is required to run the server") from exc
+
+    uvicorn.run(app, host=host, port=port)

--- a/questtools/storage.py
+++ b/questtools/storage.py
@@ -1,0 +1,57 @@
+"""Utility helpers for storing and loading quest documents."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .models import Quest, QuestDocument
+
+
+def _quest_from_dict(data: Dict[str, object]) -> Quest:
+    """Create a :class:`Quest` instance from a dictionary."""
+
+    return Quest(
+        id=int(data.get("id", 0)),
+        title=str(data.get("title", "")),
+        description=data.get("description"),
+        accept_npc=data.get("accept_npc"),
+        complete_npc=data.get("complete_npc"),
+        dialog_accept=list(data.get("dialog_accept", []) or []),
+        dialog_complete=list(data.get("dialog_complete", []) or []),
+        targets=list(data.get("targets", []) or []),
+        notes=list(data.get("notes", []) or []),
+        extra_fields=dict(data.get("extra_fields", {}) or {}),
+    )
+
+
+def load_document(path: Path | str) -> QuestDocument:
+    """Load a quest document from a JSON file."""
+
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(f"Quest data file not found: {file_path}")
+
+    with file_path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    quests_data: List[Dict[str, object]] = data.get("quests", [])
+    quests = [_quest_from_dict(item) for item in quests_data]
+
+    return QuestDocument(
+        title=data.get("title"),
+        overview=str(data.get("overview", "")),
+        quests=quests,
+    )
+
+
+def save_document(path: Path | str, document: QuestDocument) -> None:
+    """Serialise a quest document to a JSON file."""
+
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = document.to_dict()
+
+    with file_path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False, indent=2)

--- a/questtools/ui_launcher.py
+++ b/questtools/ui_launcher.py
@@ -1,0 +1,34 @@
+"""Standalone launcher for the QuestTools web UI."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .server import run_server
+
+
+def default_data_file() -> Path:
+    here = Path(__file__).resolve().parent.parent
+    candidate = here / "data" / "quests" / "tan_thu.json"
+    return candidate
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Launch the QuestTools management UI")
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=default_data_file(),
+        help="Quest data JSON file (mặc định: bộ nhiệm vụ Tân thủ)",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--no-browser", action="store_true", help="Không tự mở trình duyệt")
+    args = parser.parse_args(argv)
+
+    run_server(args.data, host=args.host, port=args.port, open_browser=not args.no_browser)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/questtools/ui_launcher.py
+++ b/questtools/ui_launcher.py
@@ -24,10 +24,23 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--no-browser", action="store_true", help="Không tự mở trình duyệt")
+    parser.add_argument(
+        "--open",
+        dest="open_browser",
+        action="store_true",
+        help="Tự mở trình duyệt sau khi khởi động",
+    )
+    parser.add_argument(
+        "--no-open",
+        "--no-browser",
+        dest="open_browser",
+        action="store_false",
+        help="Không tự mở trình duyệt",
+    )
+    parser.set_defaults(open_browser=True)
     args = parser.parse_args(argv)
 
-    run_server(args.data, host=args.host, port=args.port, open_browser=not args.no_browser)
+    run_server(args.data, host=args.host, port=args.port, open_browser=args.open_browser)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/questtools/web/__init__.py
+++ b/questtools/web/__init__.py
@@ -1,0 +1,5 @@
+"""Web application package for QuestTools."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/questtools/web/app.py
+++ b/questtools/web/app.py
@@ -1,0 +1,81 @@
+"""FastAPI application for the QuestTools management UI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from ..repository import QuestRepository
+from . import schemas
+
+
+def create_app(repository: QuestRepository, *, data_path: Path | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    app = FastAPI(title="QuestTools UI")
+
+    templates_dir = Path(__file__).parent / "templates"
+    static_dir = Path(__file__).parent / "static"
+    templates = Jinja2Templates(directory=str(templates_dir))
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    def get_repository() -> QuestRepository:
+        return repository
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(request: Request) -> HTMLResponse:  # pragma: no cover - template rendering
+        return templates.TemplateResponse(
+            "index.html",
+            {
+                "request": request,
+                "data_path": str(data_path) if data_path else None,
+            },
+        )
+
+    @app.get("/api/document", response_model=schemas.DocumentResponse)
+    def get_document(repo: QuestRepository = Depends(get_repository)) -> schemas.DocumentResponse:
+        document = repo.get_document()
+        quests = [schemas.QuestResponse(**quest.to_dict()) for quest in document.quests]
+        return schemas.DocumentResponse(title=document.title, overview=document.overview, quests=quests)
+
+    @app.put("/api/document", response_model=schemas.DocumentResponse)
+    def update_document(
+        payload: schemas.DocumentUpdate,
+        repo: QuestRepository = Depends(get_repository),
+    ) -> schemas.DocumentResponse:
+        document = repo.update_document(title=payload.title, overview=payload.overview)
+        quests = [schemas.QuestResponse(**quest.to_dict()) for quest in document.quests]
+        return schemas.DocumentResponse(title=document.title, overview=document.overview, quests=quests)
+
+    @app.post("/api/quests", response_model=schemas.QuestResponse, status_code=201)
+    def create_quest(
+        payload: schemas.QuestCreate,
+        repo: QuestRepository = Depends(get_repository),
+    ) -> schemas.QuestResponse:
+        quest = repo.create_quest(payload.model_dump())
+        return schemas.QuestResponse(**quest.to_dict())
+
+    @app.put("/api/quests/{quest_id}", response_model=schemas.QuestResponse)
+    def update_quest(
+        quest_id: int,
+        payload: schemas.QuestUpdate,
+        repo: QuestRepository = Depends(get_repository),
+    ) -> schemas.QuestResponse:
+        try:
+            quest = repo.update_quest(quest_id, payload.model_dump(exclude_unset=True))
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return schemas.QuestResponse(**quest.to_dict())
+
+    @app.delete("/api/quests/{quest_id}", status_code=204)
+    def delete_quest(quest_id: int, repo: QuestRepository = Depends(get_repository)) -> None:
+        try:
+            repo.delete_quest(quest_id)
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return app

--- a/questtools/web/app.py
+++ b/questtools/web/app.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -71,11 +71,14 @@ def create_app(repository: QuestRepository, *, data_path: Path | None = None) ->
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         return schemas.QuestResponse(**quest.to_dict())
 
-    @app.delete("/api/quests/{quest_id}", status_code=204)
-    def delete_quest(quest_id: int, repo: QuestRepository = Depends(get_repository)) -> None:
+    @app.delete("/api/quests/{quest_id}", status_code=204, response_class=Response)
+    def delete_quest(
+        quest_id: int, repo: QuestRepository = Depends(get_repository)
+    ) -> Response:
         try:
             repo.delete_quest(quest_id)
         except KeyError as exc:  # pragma: no cover - defensive
             raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return Response(status_code=204)
 
     return app

--- a/questtools/web/schemas.py
+++ b/questtools/web/schemas.py
@@ -1,0 +1,42 @@
+"""Pydantic schemas for the QuestTools web API."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class QuestBase(BaseModel):
+    description: Optional[str] = None
+    accept_npc: Optional[str] = None
+    complete_npc: Optional[str] = None
+    dialog_accept: List[str] = Field(default_factory=list)
+    dialog_complete: List[str] = Field(default_factory=list)
+    targets: List[str] = Field(default_factory=list)
+    notes: List[str] = Field(default_factory=list)
+    extra_fields: Dict[str, str] = Field(default_factory=dict)
+
+
+class QuestCreate(QuestBase):
+    title: str
+
+
+class QuestUpdate(QuestBase):
+    title: Optional[str] = None
+
+
+class QuestResponse(QuestBase):
+    id: int
+    title: str
+
+
+class DocumentResponse(BaseModel):
+    title: Optional[str]
+    overview: str
+    quests: List[QuestResponse]
+
+
+class DocumentUpdate(BaseModel):
+    title: Optional[str]
+    overview: str

--- a/questtools/web/static/styles.css
+++ b/questtools/web/static/styles.css
@@ -1,0 +1,63 @@
+body {
+  background: #f4f6fb;
+  font-family: 'Inter', 'Segoe UI', Tahoma, sans-serif;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.navbar {
+  min-height: 64px;
+}
+
+.card {
+  border-radius: 1rem;
+  border: none;
+}
+
+.card .card-header {
+  border-top-left-radius: 1rem !important;
+  border-top-right-radius: 1rem !important;
+}
+
+.quest-list {
+  max-height: calc(100vh - 220px);
+  overflow-y: auto;
+}
+
+.quest-list .list-group-item {
+  border: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.quest-list .list-group-item:last-child {
+  border-bottom: 0;
+}
+
+.quest-list .list-group-item.active {
+  background: linear-gradient(135deg, #3f8efc, #5b6dfd);
+  border-color: transparent;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1050;
+}
+
+@media (max-width: 992px) {
+  .quest-list {
+    max-height: 360px;
+  }
+}

--- a/questtools/web/templates/index.html
+++ b/questtools/web/templates/index.html
@@ -1,0 +1,580 @@
+<!DOCTYPE html>
+<html lang="vi" data-bs-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>QuestTools UI</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+    />
+    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
+  </head>
+  <body>
+    <div id="app" class="app-shell">
+      <header class="navbar navbar-dark bg-primary shadow-sm">
+        <div class="container-fluid align-items-center">
+          <span class="navbar-brand fw-semibold">QuestTools</span>
+          <div class="d-flex align-items-center gap-2">
+            <span class="badge bg-light text-primary text-wrap" v-if="dataPath">
+              {{ '{{' }} dataPath {{ '}}' }}
+            </span>
+            <button class="btn btn-outline-light btn-sm" @click="loadDocument" :disabled="loading">
+              <span class="spinner-border spinner-border-sm" v-if="loading"></span>
+              <span v-else class="bi bi-arrow-repeat"></span>
+              Tải lại dữ liệu
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main class="flex-grow-1">
+        <div class="container-fluid py-4">
+          <div v-if="message" :class="['alert','alert-dismissible','fade','show', messageClass]">
+            <span>{{ '{{' }} message {{ '}}' }}</span>
+            <button type="button" class="btn-close" @click="clearMessage"></button>
+          </div>
+
+          <div class="row g-4">
+            <div class="col-lg-3">
+              <div class="card shadow-sm h-100">
+                <div class="card-header bg-white border-0">
+                  <div class="d-flex align-items-center gap-2">
+                    <div class="input-group input-group-sm flex-grow-1">
+                      <span class="input-group-text"><i class="bi bi-search"></i></span>
+                      <input
+                        type="search"
+                        class="form-control"
+                        placeholder="Tìm nhiệm vụ..."
+                        v-model="searchQuery"
+                        :disabled="loading"
+                      />
+                    </div>
+                    <button class="btn btn-sm btn-outline-primary" @click="startCreate" :disabled="loading">
+                      <i class="bi bi-plus-lg"></i>
+                    </button>
+                  </div>
+                </div>
+                <div class="list-group list-group-flush quest-list">
+                  <button
+                    v-for="quest in filteredQuests"
+                    :key="quest.id"
+                    type="button"
+                    class="list-group-item list-group-item-action"
+                    :class="{ active: quest.id === selectedQuestId }"
+                    @click="selectQuest(quest)"
+                    :disabled="loading"
+                  >
+                    <div class="d-flex justify-content-between align-items-center">
+                      <div>
+                        <div class="fw-semibold">#{{ '{{' }} quest.id {{ '}}' }} · {{ '{{' }} quest.title {{ '}}' }}</div>
+                        <small class="text-muted" v-if="quest.accept_npc">
+                          Nhận từ: {{ '{{' }} quest.accept_npc {{ '}}' }}
+                        </small>
+                      </div>
+                      <i class="bi bi-chevron-right"></i>
+                    </div>
+                  </button>
+                  <div class="p-3 text-center text-muted" v-if="!filteredQuests.length">
+                    Không có nhiệm vụ phù hợp
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="col-lg-9">
+              <div class="card shadow-sm mb-4">
+                <div class="card-header bg-white border-0">
+                  <h5 class="card-title mb-0">Tổng quan tài liệu</h5>
+                </div>
+                <div class="card-body">
+                  <form class="row gy-3" @submit.prevent="saveDocument">
+                    <div class="col-12 col-md-6">
+                      <label class="form-label">Tiêu đề</label>
+                      <input
+                        type="text"
+                        class="form-control"
+                        v-model="documentMeta.title"
+                        :disabled="loading"
+                        placeholder="Tên tài liệu"
+                      />
+                    </div>
+                    <div class="col-12 col-md-6">
+                      <label class="form-label">Số lượng nhiệm vụ</label>
+                      <input type="text" class="form-control" :value="quests.length" disabled />
+                    </div>
+                    <div class="col-12">
+                      <label class="form-label">Tóm tắt / Ghi chú</label>
+                      <textarea
+                        class="form-control"
+                        rows="4"
+                        v-model="documentMeta.overview"
+                        :disabled="loading"
+                        placeholder="Mô tả tổng quan về chuỗi nhiệm vụ"
+                      ></textarea>
+                    </div>
+                    <div class="col-12 d-flex justify-content-end gap-2">
+                      <button type="button" class="btn btn-outline-secondary" @click="resetDocument" :disabled="!metaDirty || loading">
+                        Khôi phục
+                      </button>
+                      <button type="submit" class="btn btn-primary" :disabled="!metaDirty || loading">
+                        Lưu tổng quan
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+
+              <div class="card shadow-sm">
+                <div class="card-header bg-white border-0 d-flex justify-content-between align-items-center">
+                  <div>
+                    <h5 class="card-title mb-0" v-if="creating">
+                      Thêm nhiệm vụ mới
+                    </h5>
+                    <h5 class="card-title mb-0" v-else-if="selectedQuest">
+                      #{{ '{{' }} selectedQuest.id {{ '}}' }} · {{ '{{' }} selectedQuest.title {{ '}}' }}
+                    </h5>
+                    <h5 class="card-title mb-0" v-else>
+                      Chọn một nhiệm vụ để bắt đầu
+                    </h5>
+                  </div>
+                  <div class="d-flex gap-2" v-if="selectedQuest || creating">
+                    <button class="btn btn-outline-secondary btn-sm" @click="cancelQuestChanges" :disabled="!questDirty || loading">
+                      Hủy thay đổi
+                    </button>
+                    <button class="btn btn-primary btn-sm" @click="saveQuest" :disabled="!questDirty || loading">
+                      Lưu nhiệm vụ
+                    </button>
+                    <button
+                      class="btn btn-danger btn-sm"
+                      v-if="selectedQuest"
+                      @click="deleteQuest"
+                      :disabled="loading"
+                    >
+                      Xóa
+                    </button>
+                  </div>
+                </div>
+                <div class="card-body">
+                  <div v-if="selectedQuest || creating">
+                    <div class="row gy-3">
+                      <div class="col-12">
+                        <label class="form-label">Tên nhiệm vụ</label>
+                        <input type="text" class="form-control" v-model="questForm.title" :disabled="loading" />
+                      </div>
+                      <div class="col-12 col-lg-6">
+                        <label class="form-label">NPC nhận nhiệm vụ</label>
+                        <input type="text" class="form-control" v-model="questForm.accept_npc" :disabled="loading" />
+                      </div>
+                      <div class="col-12 col-lg-6">
+                        <label class="form-label">NPC hoàn thành</label>
+                        <input type="text" class="form-control" v-model="questForm.complete_npc" :disabled="loading" />
+                      </div>
+                      <div class="col-12">
+                        <label class="form-label">Mô tả</label>
+                        <textarea class="form-control" rows="3" v-model="questForm.description" :disabled="loading"></textarea>
+                      </div>
+                      <div class="col-12 col-lg-6">
+                        <label class="form-label">Hội thoại khi nhận</label>
+                        <textarea
+                          class="form-control"
+                          rows="4"
+                          v-model="questForm.dialog_accept_text"
+                          :disabled="loading"
+                          placeholder="Mỗi dòng tương ứng một câu"
+                        ></textarea>
+                      </div>
+                      <div class="col-12 col-lg-6">
+                        <label class="form-label">Hội thoại khi hoàn thành</label>
+                        <textarea
+                          class="form-control"
+                          rows="4"
+                          v-model="questForm.dialog_complete_text"
+                          :disabled="loading"
+                          placeholder="Mỗi dòng tương ứng một câu"
+                        ></textarea>
+                      </div>
+                      <div class="col-12 col-lg-6">
+                        <label class="form-label">Mục tiêu</label>
+                        <textarea
+                          class="form-control"
+                          rows="4"
+                          v-model="questForm.targets_text"
+                          :disabled="loading"
+                          placeholder="Mỗi dòng là một mục tiêu"
+                        ></textarea>
+                      </div>
+                      <div class="col-12 col-lg-6">
+                        <label class="form-label">Ghi chú thêm</label>
+                        <textarea
+                          class="form-control"
+                          rows="4"
+                          v-model="questForm.notes_text"
+                          :disabled="loading"
+                          placeholder="Mỗi dòng là một ghi chú"
+                        ></textarea>
+                      </div>
+                      <div class="col-12">
+                        <label class="form-label">Extra fields (JSON)</label>
+                        <textarea
+                          class="form-control font-monospace"
+                          rows="4"
+                          v-model="questForm.extra_fields_text"
+                          :disabled="loading"
+                          placeholder="{ \"key\": \"value\" }"
+                        ></textarea>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="text-center text-muted py-5" v-else>
+                    <i class="bi bi-diagram-3 display-6 d-block mb-3"></i>
+                    <p class="mb-0">Hãy chọn một nhiệm vụ ở danh sách bên trái hoặc tạo mới.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <div class="loading-overlay" v-if="loading">
+        <div class="spinner-border text-primary" role="status"></div>
+      </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/vue@3.4.21/dist/vue.global.prod.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      const splitLines = (value) => {
+        if (!value || !value.trim()) {
+          return [];
+        }
+        return value
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0);
+      };
+
+      const clone = (obj) => JSON.parse(JSON.stringify(obj));
+
+      Vue.createApp({
+        data() {
+          return {
+            loading: false,
+            quests: [],
+            selectedQuestId: null,
+            creating: false,
+            questForm: this.emptyQuestForm(),
+            questOriginal: this.emptyQuestForm(),
+            documentMeta: { title: '', overview: '' },
+            documentOriginal: { title: '', overview: '' },
+            message: '',
+            messageType: 'success',
+            searchQuery: '',
+            dataPath: {{ (data_path or '') | tojson }} || '',
+            messageTimer: null,
+          };
+        },
+        computed: {
+          filteredQuests() {
+            if (!this.searchQuery.trim()) {
+              return this.quests;
+            }
+            const term = this.searchQuery.trim().toLowerCase();
+            return this.quests.filter((quest) => {
+              return (
+                quest.title.toLowerCase().includes(term) ||
+                String(quest.id).includes(term) ||
+                (quest.accept_npc && quest.accept_npc.toLowerCase().includes(term))
+              );
+            });
+          },
+          selectedQuest() {
+            if (this.selectedQuestId == null) {
+              return null;
+            }
+            return this.quests.find((quest) => quest.id === this.selectedQuestId) || null;
+          },
+          messageClass() {
+            return `alert-${this.messageType}`;
+          },
+          metaDirty() {
+            return JSON.stringify(this.normaliseMeta(this.documentMeta)) !== JSON.stringify(this.normaliseMeta(this.documentOriginal));
+          },
+          questDirty() {
+            return JSON.stringify(this.normaliseQuestForm(this.questForm)) !== JSON.stringify(this.normaliseQuestForm(this.questOriginal));
+          },
+        },
+        created() {
+          this.loadDocument();
+        },
+        methods: {
+          emptyQuestForm() {
+            return {
+              id: null,
+              title: '',
+              description: '',
+              accept_npc: '',
+              complete_npc: '',
+              dialog_accept_text: '',
+              dialog_complete_text: '',
+              targets_text: '',
+              notes_text: '',
+              extra_fields_text: '{}'
+            };
+          },
+          normaliseMeta(meta) {
+            return {
+              title: meta.title && meta.title.trim() ? meta.title.trim() : null,
+              overview: meta.overview || '',
+            };
+          },
+          normaliseQuestForm(form) {
+            return {
+              title: form.title || '',
+              description: form.description || '',
+              accept_npc: form.accept_npc || '',
+              complete_npc: form.complete_npc || '',
+              dialog_accept_text: form.dialog_accept_text || '',
+              dialog_complete_text: form.dialog_complete_text || '',
+              targets_text: form.targets_text || '',
+              notes_text: form.notes_text || '',
+              extra_fields_text: form.extra_fields_text || '{}',
+            };
+          },
+          async loadDocument() {
+            try {
+              this.loading = true;
+              const response = await fetch('/api/document');
+              if (!response.ok) {
+                throw new Error('Không thể tải dữ liệu.');
+              }
+              const data = await response.json();
+              this.quests = data.quests;
+              this.documentMeta = {
+                title: data.title || '',
+                overview: data.overview || '',
+              };
+              this.documentOriginal = clone(this.documentMeta);
+              if (this.selectedQuestId) {
+                const quest = this.quests.find((item) => item.id === this.selectedQuestId);
+                if (quest) {
+                  this.selectQuest(quest);
+                } else {
+                  this.clearQuestSelection();
+                }
+              }
+              this.showMessage('success', 'Đã tải dữ liệu mới nhất.');
+            } catch (error) {
+              this.showMessage('danger', error.message || 'Đã xảy ra lỗi.');
+            } finally {
+              this.loading = false;
+            }
+          },
+          prepareQuestForm(quest) {
+            if (!quest) {
+              return this.emptyQuestForm();
+            }
+            return {
+              id: quest.id,
+              title: quest.title || '',
+              description: quest.description || '',
+              accept_npc: quest.accept_npc || '',
+              complete_npc: quest.complete_npc || '',
+              dialog_accept_text: (quest.dialog_accept || []).join('\n'),
+              dialog_complete_text: (quest.dialog_complete || []).join('\n'),
+              targets_text: (quest.targets || []).join('\n'),
+              notes_text: (quest.notes || []).join('\n'),
+              extra_fields_text: JSON.stringify(quest.extra_fields || {}, null, 2) || '{}'
+            };
+          },
+          selectQuest(quest) {
+            this.creating = false;
+            this.selectedQuestId = quest.id;
+            const form = this.prepareQuestForm(quest);
+            this.questForm = clone(form);
+            this.questOriginal = clone(form);
+          },
+          clearQuestSelection() {
+            this.selectedQuestId = null;
+            this.creating = false;
+            this.questForm = this.emptyQuestForm();
+            this.questOriginal = this.emptyQuestForm();
+          },
+          startCreate() {
+            this.creating = true;
+            this.selectedQuestId = null;
+            const form = this.emptyQuestForm();
+            this.questForm = clone(form);
+            this.questOriginal = clone(form);
+          },
+          resetDocument() {
+            this.documentMeta = clone(this.documentOriginal);
+          },
+          async saveDocument() {
+            try {
+              this.loading = true;
+              const payload = this.normaliseMeta(this.documentMeta);
+              const response = await fetch('/api/document', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+              });
+              if (!response.ok) {
+                throw new Error('Không thể lưu tổng quan.');
+              }
+              const data = await response.json();
+              this.documentMeta = {
+                title: data.title || '',
+                overview: data.overview || '',
+              };
+              this.documentOriginal = clone(this.documentMeta);
+              this.showMessage('success', 'Đã lưu tổng quan.');
+            } catch (error) {
+              this.showMessage('danger', error.message || 'Đã xảy ra lỗi khi lưu.');
+            } finally {
+              this.loading = false;
+            }
+          },
+          parseExtraFields(text) {
+            const trimmed = text.trim();
+            if (!trimmed) {
+              return {};
+            }
+            try {
+              const parsed = JSON.parse(trimmed);
+              if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                throw new Error();
+              }
+              const cleaned = {};
+              Object.entries(parsed).forEach(([key, value]) => {
+                cleaned[String(key)] = value != null ? String(value) : '';
+              });
+              return cleaned;
+            } catch (error) {
+              throw new Error('Extra fields phải là JSON hợp lệ.');
+            }
+          },
+          buildQuestPayload(form) {
+            if (!form.title || !form.title.trim()) {
+              throw new Error('Tên nhiệm vụ không được để trống.');
+            }
+            return {
+              title: form.title.trim(),
+              description: form.description && form.description.trim() ? form.description.trim() : null,
+              accept_npc: form.accept_npc && form.accept_npc.trim() ? form.accept_npc.trim() : null,
+              complete_npc: form.complete_npc && form.complete_npc.trim() ? form.complete_npc.trim() : null,
+              dialog_accept: splitLines(form.dialog_accept_text),
+              dialog_complete: splitLines(form.dialog_complete_text),
+              targets: splitLines(form.targets_text),
+              notes: splitLines(form.notes_text),
+              extra_fields: this.parseExtraFields(form.extra_fields_text || '{}'),
+            };
+          },
+          async saveQuest() {
+            try {
+              this.loading = true;
+              const payload = this.buildQuestPayload(this.questForm);
+              let response;
+              if (this.creating) {
+                response = await fetch('/api/quests', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(payload),
+                });
+              } else if (this.selectedQuestId != null) {
+                response = await fetch(`/api/quests/${this.selectedQuestId}`, {
+                  method: 'PUT',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(payload),
+                });
+              } else {
+                throw new Error('Không xác định được nhiệm vụ để lưu.');
+              }
+
+              if (!response.ok) {
+                throw new Error('Không thể lưu nhiệm vụ.');
+              }
+
+              const data = await response.json();
+              if (this.creating) {
+                this.quests.push(data);
+                this.quests.sort((a, b) => a.id - b.id);
+                this.selectQuest(data);
+                this.creating = false;
+                this.showMessage('success', 'Đã tạo nhiệm vụ mới.');
+              } else {
+                const index = this.quests.findIndex((quest) => quest.id === data.id);
+                if (index !== -1) {
+                  this.quests.splice(index, 1, data);
+                }
+                this.selectQuest(data);
+                this.showMessage('success', 'Đã cập nhật nhiệm vụ.');
+              }
+            } catch (error) {
+              this.showMessage('danger', error.message || 'Đã xảy ra lỗi khi lưu nhiệm vụ.');
+            } finally {
+              this.loading = false;
+            }
+          },
+          cancelQuestChanges() {
+            this.questForm = clone(this.questOriginal);
+          },
+          async deleteQuest() {
+            if (!this.selectedQuestId) {
+              return;
+            }
+            const confirmDelete = window.confirm('Bạn có chắc muốn xóa nhiệm vụ này?');
+            if (!confirmDelete) {
+              return;
+            }
+            try {
+              this.loading = true;
+              const response = await fetch(`/api/quests/${this.selectedQuestId}`, {
+                method: 'DELETE',
+              });
+              if (response.status !== 204) {
+                throw new Error('Không thể xóa nhiệm vụ.');
+              }
+              this.quests = this.quests.filter((quest) => quest.id !== this.selectedQuestId);
+              this.clearQuestSelection();
+              this.showMessage('success', 'Đã xóa nhiệm vụ.');
+            } catch (error) {
+              this.showMessage('danger', error.message || 'Đã xảy ra lỗi khi xóa.');
+            } finally {
+              this.loading = false;
+            }
+          },
+          showMessage(type, text) {
+            this.messageType = type;
+            this.message = text;
+            if (this.messageTimer) {
+              clearTimeout(this.messageTimer);
+            }
+            this.messageTimer = setTimeout(() => {
+              this.message = '';
+            }, 3500);
+          },
+          clearMessage() {
+            if (this.messageTimer) {
+              clearTimeout(this.messageTimer);
+            }
+            this.message = '';
+          },
+        },
+      }).mount('#app');
+    </script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110,<0.112
+uvicorn[standard]>=0.27,<0.28
+jinja2>=3.1,<3.2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,40 @@
+import unittest
+from pathlib import Path
+
+from questtools.parser import parse_document
+
+
+class ParserIntegrationTest(unittest.TestCase):
+    DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "raw" / "tan_thu.txt"
+
+    def test_parse_document_creates_expected_quests(self) -> None:
+        text = self.DATA_PATH.read_text(encoding="utf-8")
+        document = parse_document(text)
+
+        self.assertEqual(document.title, "Cốt truyện và Nhiệm vụ Tân thủ")
+        self.assertEqual(len(document.quests), 30)
+
+        first = document.quests[0]
+        self.assertEqual(first.title, "Rừng tre ban sớm")
+        self.assertIn("Vác rìu đi vào rừng tre", first.description)
+        self.assertEqual(first.accept_npc, "(Auto - mở màn)")
+        self.assertTrue(first.dialog_accept)
+        self.assertTrue(first.targets)
+
+        last = document.quests[-1]
+        self.assertEqual(last.title, "Những ngày chuẩn bị")
+        self.assertTrue("luyện côn" in " ".join(last.notes) or last.description is None)
+
+    def test_conversion_to_json_structure(self) -> None:
+        text = self.DATA_PATH.read_text(encoding="utf-8")
+        document = parse_document(text)
+        payload = document.to_dict()
+
+        self.assertIn("overview", payload)
+        self.assertIn("quests", payload)
+        self.assertEqual(len(payload["quests"]), 30)
+        self.assertIsInstance(payload["quests"][0]["dialog_accept"], list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,60 @@
+"""Tests for the quest repository layer."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from questtools.repository import QuestRepository
+
+
+class QuestRepositoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.data_path = Path(self.tmpdir.name) / "quests.json"
+        self.repository = QuestRepository(self.data_path)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def _load_raw(self) -> dict:
+        if not self.data_path.exists():
+            return {}
+        return json.loads(self.data_path.read_text(encoding="utf-8"))
+
+    def test_create_update_delete_quest(self) -> None:
+        quest = self.repository.create_quest({"title": "Test quest", "targets": ["Do something"]})
+        self.assertEqual(quest.title, "Test quest")
+        self.assertEqual(quest.targets, ["Do something"])
+
+        quest = self.repository.update_quest(
+            quest.id,
+            {
+                "title": "Updated quest",
+                "description": "New description",
+                "targets": ["First", "Second"],
+                "dialog_accept": ["Xin chào"],
+            },
+        )
+        self.assertEqual(quest.title, "Updated quest")
+        self.assertEqual(quest.targets, ["First", "Second"])
+        self.assertEqual(quest.dialog_accept, ["Xin chào"])
+
+        self.repository.delete_quest(quest.id)
+        data = self._load_raw()
+        self.assertEqual(data.get("quests"), [])
+
+    def test_update_document_metadata(self) -> None:
+        document = self.repository.update_document(title="Tài liệu", overview="Mô tả")
+        self.assertEqual(document.title, "Tài liệu")
+        self.assertEqual(document.overview, "Mô tả")
+
+        data = self._load_raw()
+        self.assertEqual(data.get("title"), "Tài liệu")
+        self.assertEqual(data.get("overview"), "Mô tả")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,0 +1,61 @@
+"""Tests for the FastAPI web layer."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from questtools.repository import QuestRepository
+from questtools.web import create_app
+
+
+class WebApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.data_path = Path(self.tmpdir.name) / "quests.json"
+        self.repository = QuestRepository(self.data_path)
+        self.client = TestClient(create_app(self.repository, data_path=self.data_path))
+
+    def tearDown(self) -> None:
+        self.client.close()
+        self.tmpdir.cleanup()
+
+    def test_document_crud_flow(self) -> None:
+        response = self.client.get("/api/document")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["quests"], [])
+
+        create_resp = self.client.post("/api/quests", json={"title": "Quest A"})
+        self.assertEqual(create_resp.status_code, 201)
+        quest = create_resp.json()
+        self.assertEqual(quest["title"], "Quest A")
+
+        quest_id = quest["id"]
+        update_resp = self.client.put(
+            f"/api/quests/{quest_id}",
+            json={"title": "Quest A+", "targets": ["Do X"]},
+        )
+        self.assertEqual(update_resp.status_code, 200)
+        self.assertEqual(update_resp.json()["targets"], ["Do X"])
+
+        document_update = self.client.put(
+            "/api/document",
+            json={"title": "Story", "overview": "Mô tả"},
+        )
+        self.assertEqual(document_update.status_code, 200)
+        self.assertEqual(document_update.json()["title"], "Story")
+
+        delete_resp = self.client.delete(f"/api/quests/{quest_id}")
+        self.assertEqual(delete_resp.status_code, 204)
+
+        final_resp = self.client.get("/api/document")
+        self.assertEqual(final_resp.status_code, 200)
+        self.assertEqual(final_resp.json()["quests"], [])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a QuestTools CLI with commands to convert, list, show, add, update, and remove quests
- implement parsing, storage, and data models for quest documents and convert the Tan Thu quest file to JSON
- document usage in the README and add unit tests for the parser

## Testing
- python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68d36e04eed4832d8e7304d6989c7cda